### PR TITLE
Add config option to disable Arm at Home for the alarm panel

### DIFF
--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -32,7 +32,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import DATA_COORDINATOR, DOMAIN, USE_CODE_ARMING, INTERNAL_API, ENABLE_DEBUG_OUTPUT, ALLOW_SUBSYSTEMS
+from .const import DATA_COORDINATOR, DOMAIN, USE_CODE_ARMING, INTERNAL_API, ENABLE_DEBUG_OUTPUT, ALLOW_SUBSYSTEMS, DISABLE_ARM_HOME
 from .model import ZonesResponse, Zone, SubSystemResponse, SubSys, Arming, ZonesConf, ZoneConfig, RelaySwitchConf, OutputStatusFull, RelayStatusSearchResponse, OutputConfList, JSONResponseStatus, ExDevStatusResponse
 
 PLATFORMS: list[Platform] = [Platform.ALARM_CONTROL_PANEL, Platform.SENSOR, Platform.SWITCH]
@@ -73,6 +73,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     code_format = entry.data[ATTR_CODE_FORMAT]
     code = entry.data[CONF_CODE]
     use_code_arming = entry.data[USE_CODE_ARMING]
+    disable_arm_home = entry.data[DISABLE_ARM_HOME]
     use_sub_systems = entry.data.get(ALLOW_SUBSYSTEMS, False)
     axpro = hikaxpro.HikAxPro(host, username, password)
     if entry.data.get(INTERNAL_API):
@@ -100,6 +101,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         use_code_arming,
         code,
         update_interval,
+        disable_arm_home,
         use_sub_systems
     )
     try:
@@ -154,6 +156,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         use_code_arming,
         code,
         update_interval: float,
+        disable_arm_home,
         use_sub_systems = False
     ):
         self.axpro = axpro
@@ -165,6 +168,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         self.code_format = code_format
         self.use_code_arming = use_code_arming
         self.code = code
+        self.disable_arm_home = disable_arm_home
         self.use_sub_systems = use_sub_systems
         super().__init__(hass, _LOGGER, name=DOMAIN, update_interval=timedelta(seconds=update_interval))
 

--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -47,16 +47,21 @@ async def async_setup_entry(
 
 class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     """Representation of Hikvision Ax Pro alarm panel."""
+    def __init__(self, coordinator: HikAxProDataUpdateCoordinator):
+        if not coordinator.disable_arm_home:
+            """if ARM_HOME shouldn't be disabled, add it to the supported features"""
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
+
+        super().__init__(coordinator=coordinator)
     _attr_code_arm_required = False
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
         self.async_write_ha_state()
 
-    _attr_supported_features = (
-        AlarmControlPanelEntityFeature.ARM_HOME
-        | AlarmControlPanelEntityFeature.ARM_AWAY
-    )
+    _attr_supported_features = (AlarmControlPanelEntityFeature.ARM_HOME)
+
+   
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -137,6 +142,9 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
 
     def __init__(self, coordinator: HikAxProDataUpdateCoordinator, sys: SubSys):
         self.sys = sys
+        if not coordinator.disable_arm_home:
+            """if ARM_HOME shouldn't be disabled, add it to the supported features"""
+            self._attr_supported_features |= AlarmControlPanelEntityFeature.ARM_AWAY
         super().__init__(coordinator=coordinator)
 
 
@@ -150,10 +158,7 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
             logging.warning("Area %s was not found", self.sys.id)
         self.async_write_ha_state()
 
-    _attr_supported_features = (
-        AlarmControlPanelEntityFeature.ARM_HOME
-        | AlarmControlPanelEntityFeature.ARM_AWAY
-    )
+    _attr_supported_features = (AlarmControlPanelEntityFeature.ARM_HOME)
 
 
 

--- a/custom_components/hikvision_axpro/config_flow.py
+++ b/custom_components/hikvision_axpro/config_flow.py
@@ -19,11 +19,11 @@ from homeassistant.const import (
     CONF_HOST,
     CONF_USERNAME,
     CONF_PASSWORD,
-    CONF_SCAN_INTERVAL,
+    CONF_SCAN_INTERVAL
 )
 from homeassistant.components.alarm_control_panel import SCAN_INTERVAL
 
-from .const import DOMAIN, USE_CODE_ARMING, ALLOW_SUBSYSTEMS, INTERNAL_API, ENABLE_DEBUG_OUTPUT
+from .const import DOMAIN, USE_CODE_ARMING, ALLOW_SUBSYSTEMS, INTERNAL_API, ENABLE_DEBUG_OUTPUT, DISABLE_ARM_HOME
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,6 +36,7 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(ATTR_CODE_FORMAT, default="NUMBER"): vol.In(["TEXT", "NUMBER"]),
         vol.Optional(CONF_CODE, default=""): str,
         vol.Optional(USE_CODE_ARMING, default=False): bool,
+        vol.Optional(DISABLE_ARM_HOME, default=False): bool,
         vol.Required(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL.total_seconds()): int,
         vol.Optional(ALLOW_SUBSYSTEMS, default=False): bool,
         vol.Optional(INTERNAL_API, default=False): bool,
@@ -53,6 +54,7 @@ CONFIGURE_SCHEMA = vol.Schema(
         vol.Optional(ATTR_CODE_FORMAT, default="NUMBER"): vol.In(["TEXT", "NUMBER"]),
         vol.Optional(CONF_CODE, default=""): str,
         vol.Optional(USE_CODE_ARMING, default=False): bool,
+        vol.Optional(DISABLE_ARM_HOME, default=False): bool,
         vol.Required(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL.total_seconds()): int,
         vol.Optional(ALLOW_SUBSYSTEMS, default=False): bool,
         vol.Optional(INTERNAL_API, default=False): bool,

--- a/custom_components/hikvision_axpro/const.py
+++ b/custom_components/hikvision_axpro/const.py
@@ -14,6 +14,8 @@ INTERNAL_API: Final[str] = "internal_api"
 
 ENABLE_DEBUG_OUTPUT: Final[str] = "debug"
 
+DISABLE_ARM_HOME: Final[str] = "disable_arm_home"
+
 
 # Sensor entity description constants
 ENTITY_DESC_KEY_BATTERY: Final[str] = "battery"

--- a/custom_components/hikvision_axpro/strings.json
+++ b/custom_components/hikvision_axpro/strings.json
@@ -11,6 +11,7 @@
             "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
             "code": "[%key:common::config_flow::data::code%]",
             "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+            "disable_arm_home": "[%key:common::config_flow::data::disable_arm_home%]",
             "internal_api": "[%key:common::config_flow::data::internal_api%]"
           }
         }
@@ -38,6 +39,7 @@
             "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
             "code": "[%key:common::config_flow::data::code%]",
             "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+            "disable_arm_home": "[%key:common::config_flow::data::disable_arm_home%]",
             "internal_api": "[%key:common::config_flow::data::internal_api%]"
           }
         }

--- a/custom_components/hikvision_axpro/translations/en.json
+++ b/custom_components/hikvision_axpro/translations/en.json
@@ -23,6 +23,7 @@
                     "allow_subsystems": "Include areas as separate zones for arm/disarm",
                     "code": "Code",
                     "scan_interval": "Pull interval from system",
+                    "disable_arm_home": "Remove option to arm in Home mode",
                     "internal_api": "Use internal API lib (AXHub)",
                     "debug": "Enable debug output"
                 }
@@ -42,6 +43,7 @@
                     "allow_subsystems": "Include areas as separate zones for arm/disarm",
                     "code": "Code",
                     "scan_interval": "Pull interval from system",
+                    "disable_arm_home": "Remove option to arm in Home mode",
                     "internal_api": "DEPRECATED - Use internal API lib (AXHub)",
                     "debug": "Enable debug output"
                 }

--- a/custom_components/hikvision_axpro/translations/it.json
+++ b/custom_components/hikvision_axpro/translations/it.json
@@ -23,6 +23,7 @@
                     "allow_subsystems": "Includi aree come zone separate per armare/disarmare",
                     "code": "Codice",
                     "scan_interval": "Intervallo di scansione del sistema",
+                    "disable_arm_home": "Rimuovi l'opzione per armare in modalità a Casa",
                     "internal_api": "Usa la libreria API interna (AXHub)",
                     "debug": "Abilita l'output di debug"
                 }
@@ -42,6 +43,7 @@
                     "allow_subsystems": "Includi aree come zone separate per armare/disarmare",
                     "code": "Codice",
                     "scan_interval": "Intervallo di scansione del sistema",
+                    "disable_arm_home": "Rimuovi l'opzione per armare in modalità a Casa",
                     "internal_api": "OBSOLETA - Usa la libreria API interna (AXHub)",
                     "debug": "Abilita l'output di debug"
                 }


### PR DESCRIPTION
I've started using the integration, but in my use case of the alarm panel, i will never use the "Home" arming mode, as such, i thought it could be nice to have an option to disable it in the config flow and having only "Arm Away" and "Disarm" in the Panel.

this PR does exactly that by adding an option in the config flow, and works for both the mail panel and the Areas subpanels. The default configuration does not modify the current behavior of the integration

![image](https://github.com/user-attachments/assets/edf90c0a-75b5-40c2-9d60-ad9e62931083)


![image](https://github.com/user-attachments/assets/d131b507-acce-4d85-ac90-9abc2da03f26)


I've only added the string for the English language, so that probably needs to be addressed, i added the Italian string as that is my native language, but i would like to hear what's the correct practice for this repo, should we leave the string as is and wait for contributions from native speaking people or should we translate the string with an online service?