### PR TITLE
fix deprecation warnings for alarm states

### DIFF
--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -11,7 +11,10 @@ from .hikax import hikax
 
 from async_timeout import timeout
 
-from homeassistant.components.alarm_control_panel import SCAN_INTERVAL
+from homeassistant.components.alarm_control_panel import (
+    SCAN_INTERVAL,
+    AlarmControlPanelState,
+)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_CODE_FORMAT,
@@ -22,11 +25,7 @@ from homeassistant.const import (
     CONF_CODE,
     CONF_SCAN_INTERVAL,
     Platform,
-    STATE_ALARM_ARMED_HOME,
-    STATE_ALARM_ARMED_VACATION,
-    STATE_ALARM_ARMED_AWAY,
-    STATE_ALARM_DISARMED,
-    STATE_ALARM_TRIGGERED, SERVICE_RELOAD
+    SERVICE_RELOAD
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
@@ -251,7 +250,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
 
     def _update_data(self) -> None:
         """Fetch data from axpro via sync functions."""
-        status = STATE_ALARM_DISARMED
+        status = AlarmControlPanelState.DISARMED
         status_json = self.axpro.subsystem_status()
         try:
             subsys_resp = SubSystemResponse.from_dict(status_json)
@@ -268,13 +267,13 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
                 if self.use_sub_systems and subsys.id != 1:
                     continue
                 if subsys.alarm:
-                    status = STATE_ALARM_TRIGGERED
+                    status = AlarmControlPanelState.TRIGGERED
                 elif subsys.arming == Arming.AWAY:
-                    status = STATE_ALARM_ARMED_AWAY
+                    status = AlarmControlPanelState.ARMED_AWAY
                 elif subsys.arming == Arming.STAY:
-                    status = STATE_ALARM_ARMED_HOME
+                    status = AlarmControlPanelState.ARMED_HOME
                 elif subsys.arming == Arming.VACATION:
-                    status = STATE_ALARM_ARMED_VACATION
+                    status = AlarmControlPanelState.ARMED_VACATION
             _LOGGER.debug("SubSystem status: %s", subsys_resp)
         except:
             _LOGGER.warning("Error getting status: %s", status_json)

--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import STATE_ALARM_TRIGGERED, STATE_ALARM_ARMED_AWAY, STATE_ALARM_ARMED_HOME, \
-    STATE_ALARM_ARMED_VACATION, STATE_ALARM_DISARMED
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import DeviceInfo
@@ -13,6 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.components.alarm_control_panel import (
     AlarmControlPanelEntity,
     AlarmControlPanelEntityFeature,
+    AlarmControlPanelState,
     CodeFormat,
 )
 from homeassistant.helpers import device_registry as dr
@@ -182,15 +181,15 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
     def state(self):
         """Return the state of the device."""
         if self.sys.alarm:
-            return STATE_ALARM_TRIGGERED
+            return AlarmControlPanelState.TRIGGERED
         if self.sys.arming == Arming.AWAY:
-            return STATE_ALARM_ARMED_AWAY
+            return AlarmControlPanelState.ARMED_AWAY
         if self.sys.arming == Arming.STAY:
-            return STATE_ALARM_ARMED_HOME
+            return AlarmControlPanelState.ARMED_HOME
         if self.sys.arming == Arming.VACATION:
-            return STATE_ALARM_ARMED_VACATION
+            return AlarmControlPanelState.ARMED_VACATION
         if self.sys.arming == Arming.DISARM:
-            return STATE_ALARM_DISARMED
+            return AlarmControlPanelState.DISARMED
         return None
 
     @property


### PR DESCRIPTION
We're getting some deprecation warnings for HA 2025 since this commit

https://github.com/home-assistant/core/commit/cdfec7ebb44a6b4e6e4cd29cedf1d8112d30a90c#diff-dde95b07472f470bc99104567721c422c23102237a015804dceac48df2f05f09

This PR fixes it by using Enum for alarm states instead of consts.