### PR TITLE
fix: don't require code to arm subsystem (area) panels

### DIFF
--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -140,6 +140,8 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
 class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
     """Representation of Hikvision Ax Pro alarm panel."""
 
+    _attr_code_arm_required = False
+
     sys: SubSys
     coordinator: HikAxProDataUpdateCoordinator
 


### PR DESCRIPTION
`HikAxProSubPanel` doesn't set `_attr_code_arm_required`, so it inherits Home Assistant's default of `True`. With a code configured but `use_code_arming` disabled, arming an individual area raises `ServiceValidationError: code_arm_required` (HTTP 500): HA core gates on that attribute *before* the integration's own `use_code` / `use_code_arming` check ever runs.

The master panel (`HikAxProPanel`) already sets it to `False`. This mirrors it on the subsystem panels so per-area arming without a code works the same way.

Tested on a DS-PHA64-LP(B) AX HYBRID PRO (fw V1.1.2) with 4 areas: arming each area via HA now succeeds instead of returning 500.