### PR TITLE
fix: HA 2026.x entity ID and device model compliance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v3.1.1
+- **fix**: slugify entity IDs and migrate invalid registry entries for HA 2026.x (#190, #194)
+- **fix**: pass device registry `model` as a string (never `DetectorType`) (#198)
+- **fix**: drop redundant `requests` requirement from manifest (#200)
+
 ## v3.1.0
 - **feat**: HA 2025.12 compliance #162
 

--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -41,6 +41,7 @@ from .const import (
     ENABLE_DEBUG_OUTPUT,
     USE_CODE_ARMING,
 )
+from .entity_id import migrate_invalid_entity_ids
 from .model import (
     Arming,
     ExDevStatusResponse,
@@ -184,6 +185,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         raise ConfigEntryNotReady from ex
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
+
+    migrate_invalid_entity_ids(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/hikvision_axpro/binary_sensor.py
+++ b/custom_components/hikvision_axpro/binary_sensor.py
@@ -22,7 +22,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import HikAxProDataUpdateCoordinator
 from .const import DATA_COORDINATOR, DOMAIN
 from .hik_device import HikDevice
-from .model import DetectorType, Zone, detector_model_to_name
+from .entity_id import build_entity_id
+from .model import DetectorType, Zone, zone_device_model
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -59,9 +60,7 @@ async def async_setup_entry(
                     # suggested_area=zone.zone.,
                     name=zone_config.zone_name,
                     via_device=(DOMAIN, str(coordinator.mac)),
-                    model=detector_model_to_name(zone.zone.model)
-                    if zone.zone.model is not None
-                    else detector_type,
+                    model=zone_device_model(zone.zone.model, detector_type),
                     sw_version=zone.zone.version,
                 )
             else:
@@ -80,9 +79,7 @@ async def async_setup_entry(
                     # suggested_area=zone.zone.,
                     name=zone.zone.name,
                     via_device=(DOMAIN, str(coordinator.mac)),
-                    model=detector_model_to_name(zone.zone.model)
-                    if zone.zone.model is not None
-                    else detector_type,
+                    model=zone_device_model(zone.zone.model, detector_type),
                     sw_version=zone.zone.version,
                 )
 
@@ -168,7 +165,9 @@ class HikWirelessExtMagnetDetector(CoordinatorEntity, HikDevice, BinarySensorEnt
         self._attr_icon = "mdi:magnet"
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -224,7 +223,9 @@ class HikMagneticContactDetector(CoordinatorEntity, HikDevice, BinarySensorEntit
         self._attr_unique_id = f"{self.coordinator.device_name}-magnet-{zone.id}"
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -280,8 +281,8 @@ class HikMagnetShockDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._attr_unique_id = f"{self.coordinator.device_name}-magnet-shock-{zone.id}"
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-magnet-shock-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "magnet-shock", zone.id
         )
 
     @property
@@ -347,8 +348,8 @@ class HikMagnetOpenDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._attr_unique_id = f"{self.coordinator.device_name}-magnet-open-{zone.id}"
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-magnet-open-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "magnet-open", zone.id
         )
 
     @property
@@ -414,8 +415,8 @@ class HikMagnetTiltDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._attr_unique_id = f"{self.coordinator.device_name}-magnet-tilt-{zone.id}"
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-magnet-tilt-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "magnet-tilt", zone.id
         )
 
     @property
@@ -483,7 +484,9 @@ class HikTamperDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.TAMPER
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-tamper-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "tamper", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -527,7 +530,9 @@ class HikBypassDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.SAFETY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-bypass-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "bypass", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -571,7 +576,9 @@ class HikArmedInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-armed-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "armed", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -615,7 +622,9 @@ class HikAlarmInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-alarm-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "alarm", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -659,7 +668,9 @@ class HikStayAwayInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-stayaway-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "stayaway", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -703,8 +714,8 @@ class HikIsViaRepeaterInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-isviarepeater-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "isviarepeater", zone.id
         )
 
     @property
@@ -748,8 +759,8 @@ class HikBinaryBatteryInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         self._attr_icon = "mdi:battery"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-battery-low-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "battery-low", zone.id
         )
 
     @property

--- a/custom_components/hikvision_axpro/entity_id.py
+++ b/custom_components/hikvision_axpro/entity_id.py
@@ -1,0 +1,82 @@
+"""Helpers for valid Home Assistant object/entity IDs."""
+
+from __future__ import annotations
+
+from hashlib import sha1
+import logging
+import re
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
+
+_LOGGER = logging.getLogger(__name__)
+
+INVALID_OBJECT_ID_RE = re.compile(r"[^a-z0-9_]")
+
+
+def normalized_object_id(value: str | None, fallback: str | None = None) -> str:
+    """Return a valid HA object_id slug.
+
+    Uses HA slugify first. If that produces an empty value, falls back to a
+    slugified fallback, then finally to a deterministic hash-based identifier.
+    """
+    slug = slugify(value or "")
+    if slug:
+        return slug
+
+    fallback_slug = slugify(fallback or "")
+    if fallback_slug:
+        return fallback_slug
+
+    seed = (fallback or value or "entity").encode("utf-8")
+    return f"entity_{sha1(seed).hexdigest()[:10]}"
+
+
+def has_invalid_object_id_chars(entity_id: str) -> bool:
+    """Return True when object_id contains chars outside [a-z0-9_]."""
+    if "." not in entity_id:
+        return True
+    _, object_id = entity_id.split(".", 1)
+    return bool(INVALID_OBJECT_ID_RE.search(object_id))
+
+
+def build_entity_id(domain: str, device_name: str | None, *parts: object) -> str:
+    """Build a valid entity_id: ``{domain}.{device}_{suffix}_{id}``.
+
+    Example: ``sensor.ax_pro_temperature_0``.
+    """
+    object_parts = [normalized_object_id(device_name, fallback="axpro")]
+    for part in parts:
+        if part is None:
+            continue
+        object_parts.append(normalized_object_id(str(part)))
+    return f"{domain}.{'_'.join(object_parts)}"
+
+
+def migrate_invalid_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Rename registry entries whose object_id is not a valid HA slug."""
+    registry = er.async_get(hass)
+    for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not has_invalid_object_id_chars(entity.entity_id):
+            continue
+
+        domain, object_id = entity.entity_id.split(".", 1)
+        new_object_id = normalized_object_id(object_id)
+        new_entity_id = f"{domain}.{new_object_id}"
+
+        if new_entity_id == entity.entity_id:
+            continue
+
+        if registry.async_get(new_entity_id) is not None:
+            # Avoid clobbering an existing entity; append a short unique suffix.
+            new_entity_id = f"{domain}.{new_object_id}_{entity.unique_id[-6:]}"
+            new_entity_id = (
+                f"{domain}.{normalized_object_id(new_entity_id.split('.', 1)[1])}"
+            )
+
+        _LOGGER.info(
+            "Migrating invalid entity_id %s -> %s", entity.entity_id, new_entity_id
+        )
+        registry.async_update_entity(entity.entity_id, new_entity_id=new_entity_id)

--- a/custom_components/hikvision_axpro/manifest.json
+++ b/custom_components/hikvision_axpro/manifest.json
@@ -11,8 +11,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/petrleocompel/hikaxpro_hacs/issues",
   "requirements": [
-    "hikaxpro==2.3.0",
-    "requests"
+    "hikaxpro==2.3.0"
   ],
-  "version": "3.1.0"
+  "version": "3.1.1"
 }

--- a/custom_components/hikvision_axpro/model.py
+++ b/custom_components/hikvision_axpro/model.py
@@ -118,6 +118,17 @@ class DetectorType(Enum):
     OTHER = "other"
 
 
+def zone_device_model(
+    model: Optional[str], detector_type: Optional[DetectorType]
+) -> str:
+    """Return a string device model for the HA device registry."""
+    if model is not None:
+        return detector_model_to_name(model)
+    if detector_type is not None:
+        return detector_type.value
+    return "Unknown"
+
+
 def detector_model_to_name(model_id: Optional[str]) -> str:
     if model_id == "0x00001":
         return "Passive Infrared Detector"

--- a/custom_components/hikvision_axpro/sensor.py
+++ b/custom_components/hikvision_axpro/sensor.py
@@ -29,7 +29,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from . import HikAxProDataUpdateCoordinator
 from .const import DATA_COORDINATOR, DOMAIN
 from .hik_device import HikDevice
-from .model import DetectorType, Status, Zone, detector_model_to_name
+from .entity_id import build_entity_id
+from .model import DetectorType, Status, Zone, zone_device_model
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -65,9 +66,7 @@ async def async_setup_entry(
                     # suggested_area=zone.zone.,
                     name=zone_config.zone_name,
                     via_device=(DOMAIN, str(coordinator.mac)),
-                    model=detector_model_to_name(zone.zone.model)
-                    if zone.zone.model is not None
-                    else detector_type,
+                    model=zone_device_model(zone.zone.model, detector_type),
                     sw_version=zone.zone.version,
                 )
             else:
@@ -86,9 +85,7 @@ async def async_setup_entry(
                     # suggested_area=zone.zone.,
                     name=zone.zone.name,
                     via_device=(DOMAIN, str(coordinator.mac)),
-                    model=detector_model_to_name(zone.zone.model)
-                    if zone.zone.model is not None
-                    else detector_type,
+                    model=zone_device_model(zone.zone.model, detector_type),
                     sw_version=zone.zone.version,
                 )
 
@@ -132,8 +129,8 @@ class HikTemperature(CoordinatorEntity, HikDevice, SensorEntity):
         self._device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_has_entity_name = True
-        self.entity_id = (
-            f"{SENSOR_DOMAIN}.{coordinator.device_name}-temperature-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "temperature", zone.id
         )
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
@@ -174,7 +171,9 @@ class HikHumidity(CoordinatorEntity, HikDevice, SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-humidity-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "humidity", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -213,7 +212,9 @@ class HikBatteryInfo(CoordinatorEntity, HikDevice, SensorEntity):
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-battery-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "battery", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -252,7 +253,9 @@ class HikSignalInfo(CoordinatorEntity, HikDevice, SensorEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-signal-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "signal", zone.id
+        )
 
     @property
     def name(self) -> str | None:
@@ -286,7 +289,9 @@ class HikStatusInfo(CoordinatorEntity, HikDevice, SensorEntity):
         self._ref_id = entry_id
         self._attr_unique_id = f"{self.coordinator.device_name}-status-{zone.id}"
         self._attr_has_entity_name = True
-        self.entity_id = f"{SENSOR_DOMAIN}.{coordinator.device_name}-status-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, coordinator.device_name, "status", zone.id
+        )
         if (
             self.coordinator.zones
             and self.coordinator.zones[self.zone.id]

--- a/custom_components/hikvision_axpro/switch.py
+++ b/custom_components/hikvision_axpro/switch.py
@@ -14,6 +14,7 @@ from homeassistant.components.switch import SwitchEntity, DOMAIN as SWITCH_DOMAI
 
 from . import HikAxProDataUpdateCoordinator
 from .const import DATA_COORDINATOR, DOMAIN
+from .entity_id import build_entity_id
 from .model import RelaySwitchConf, RelayStatusEnum, OutputStatusFull
 from homeassistant.const import STATE_ON, STATE_OFF, STATE_UNKNOWN
 
@@ -55,7 +56,9 @@ class HikRelaySwitch(CoordinatorEntity, SwitchEntity):
         self.switch = switch
         self._ref_id = entry_id
         self._attr_unique_id = f"{self.coordinator.device_name}-relay-{switch.id}"
-        self.entity_id = f"{SWITCH_DOMAIN}.{coordinator.device_name}-relay-{switch.id}"
+        self.entity_id = build_entity_id(
+            SWITCH_DOMAIN, coordinator.device_name, "relay", switch.id
+        )
         #self._attr_icon = "mdi:switch"
         #self._attr_has_entity_name = True
         self._attr_device_info = DeviceInfo(

--- a/tests/test_entity_id.py
+++ b/tests/test_entity_id.py
@@ -1,0 +1,118 @@
+"""Tests for entity ID helpers and platform contracts."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+COMPONENT = ROOT / "custom_components" / "hikvision_axpro"
+
+
+def _install_ha_stubs() -> None:
+    """Minimal homeassistant stubs so entity_id can load without full HA."""
+    _ha = types.ModuleType("homeassistant")
+    _ha_config_entries = types.ModuleType("homeassistant.config_entries")
+    _ha_core = types.ModuleType("homeassistant.core")
+    _ha_helpers = types.ModuleType("homeassistant.helpers")
+    _ha_entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
+    _ha_util = types.ModuleType("homeassistant.util")
+
+    def _fake_slugify(text: str) -> str:
+        text = (text or "").lower()
+        text = re.sub(r"[^a-z0-9]+", "_", text)
+        return text.strip("_")
+
+    _ha_util.slugify = _fake_slugify
+    _ha_config_entries.ConfigEntry = object
+    _ha_core.HomeAssistant = object
+    _ha_entity_registry.async_get = MagicMock()
+    _ha_entity_registry.async_entries_for_config_entry = MagicMock(return_value=[])
+    _ha_helpers.entity_registry = _ha_entity_registry
+
+    sys.modules.setdefault("homeassistant", _ha)
+    sys.modules.setdefault("homeassistant.config_entries", _ha_config_entries)
+    sys.modules.setdefault("homeassistant.core", _ha_core)
+    sys.modules.setdefault("homeassistant.helpers", _ha_helpers)
+    sys.modules.setdefault(
+        "homeassistant.helpers.entity_registry", _ha_entity_registry
+    )
+    sys.modules.setdefault("homeassistant.util", _ha_util)
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+_install_ha_stubs()
+entity_id = _load_module("hikvision_axpro_entity_id", COMPONENT / "entity_id.py")
+model = _load_module("hikvision_axpro_model", COMPONENT / "model.py")
+
+build_entity_id = entity_id.build_entity_id
+has_invalid_object_id_chars = entity_id.has_invalid_object_id_chars
+normalized_object_id = entity_id.normalized_object_id
+DetectorType = model.DetectorType
+zone_device_model = model.zone_device_model
+
+
+def test_normalized_object_id_slugifies() -> None:
+    assert normalized_object_id("AX PRO") == "ax_pro"
+    assert normalized_object_id("Main-home") == "main_home"
+    assert re.fullmatch(r"[a-z0-9_]+", normalized_object_id("Český ***", "Zone 7"))
+
+
+def test_normalized_object_id_fallback_hash() -> None:
+    result = normalized_object_id("***", fallback="")
+    assert result.startswith("entity_")
+    assert re.fullmatch(r"[a-z0-9_]+", result)
+
+
+def test_has_invalid_object_id_chars() -> None:
+    assert has_invalid_object_id_chars("sensor.AX PRO-temperature-0")
+    assert has_invalid_object_id_chars("sensor.Main-home-battery-0")
+    assert not has_invalid_object_id_chars("sensor.ax_pro_temperature_0")
+
+
+def test_build_entity_id_shape() -> None:
+    assert (
+        build_entity_id("sensor", "AX PRO", "temperature", 0)
+        == "sensor.ax_pro_temperature_0"
+    )
+    assert (
+        build_entity_id("binary_sensor", "AX PRO", "magnet-shock", 8)
+        == "binary_sensor.ax_pro_magnet_shock_8"
+    )
+
+
+def test_zone_device_model_always_str() -> None:
+    assert zone_device_model("0x00001", None) == "Passive Infrared Detector"
+    assert (
+        zone_device_model(None, DetectorType.PIR_DETECTOR)
+        == DetectorType.PIR_DETECTOR.value
+    )
+    assert isinstance(zone_device_model(None, DetectorType.SMOKE_DETECTOR), str)
+    assert zone_device_model(None, None) == "Unknown"
+
+
+@pytest.mark.parametrize(
+    "filename",
+    ("binary_sensor.py", "sensor.py", "switch.py"),
+)
+def test_platforms_do_not_assign_raw_device_name_entity_id(filename: str) -> None:
+    content = (COMPONENT / filename).read_text(encoding="utf-8")
+    assert "build_entity_id(" in content
+    assert not re.search(
+        r'self\.entity_id\s*=\s*f?["\'].*coordinator\.device_name',
+        content,
+    )


### PR DESCRIPTION
## Summary
- Slugify entity IDs (`build_entity_id`) and migrate invalid registry entries on setup (#190, #194)
- Always pass a string to device registry `model` via `zone_device_model` (#198)
- Drop redundant `requests` from `manifest.json` and bump to 3.1.1 (#200 hardening)
- Add unit tests for helpers and platform contract checks

## Test plan
- [x] Fresh install on HA 2026.7+: entities get lowercase slug IDs (e.g. `sensor.ax_pro_temperature_0`)
- [x] Restart with existing invalid IDs: registry migrates them; unique_id preserved
- [x] No log warning about non-string `DetectorType` as device model
- [x] Integration loads without `Requirements for hikvision_axpro not found`
- [x] `pytest tests/test_entity_id.py` passes


Made with [Cursor](https://cursor.com)