### PR TITLE
chore: change of the id_logic generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 test_payloads/
 __pycache__/
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+- **chore**: rework ID generation. Entity IDs are now
+  `<device>_z<zone>_<name>_<compact mac>`
+  (`binary_sensor.ingresso_z1_tamper_a4d5c26bb859`), derived from the entity's own
+  `unique_id`. The MAC stays one compact token instead of being split into six
+  (`a4_d5_c2_...`), so an underscore only ever separates two distinct pieces of
+  information. The id is unique by construction, so two panels carrying zones with
+  the same name no longer collide and Home Assistant never appends a `_2` suffix;
+  a zone number is written `z1` and the MAC always closes the id, so nothing in an
+  ID can be mistaken for such a suffix. Only numbers that really are zones are
+  marked — a hub battery or relay keeps its own plain number.
+- **chore**: key `unique_id` off the compact panel MAC (`a4d5c26bb859-tamper-1`)
+  instead of the panel's `deviceName`, which the user can change on the panel and
+  which is not unique across two panels — with two panels it silently dropped one
+  panel's entities. Subsystem panels gain the missing separator
+  (`subsys-<mac>-<area>`).
+- **chore**: migrate existing installations in place — legacy unique IDs, in both
+  the `deviceName` and the colon-MAC form, are re-keyed on the same registry rows,
+  so custom names, hand-picked entity IDs, history and automations all survive.
+  Entity IDs are only rewritten when they are no longer valid object IDs.
+
 ## v3.4.0
 - **feat**: PIR / motion detector zones expose `binary_sensor` Motion (`device_class: motion`) from zone status `trigger` (#170)
 

--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -9,6 +9,7 @@ import logging
 import hikaxpro
 import xmltodict
 
+from homeassistant.components import persistent_notification
 from homeassistant.components.alarm_control_panel import (
     SCAN_INTERVAL,
     AlarmControlPanelState,
@@ -42,7 +43,11 @@ from .const import (
     ENABLE_DEBUG_OUTPUT,
     USE_CODE_ARMING,
 )
-from .entity_id import migrate_invalid_entity_ids
+from .entity_id import (
+    has_invalid_object_id_chars,
+    normalized_mac,
+    normalized_object_id,
+)
 from .model import (
     Arming,
     ExDevStatusResponse,
@@ -72,6 +77,161 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 _LOGGER = logging.getLogger(__name__)
+
+
+def _migrated_unique_id(
+    unique_id: str, device_name: str | None, mac: str, mac_id: str
+) -> str | None:
+    """Map a legacy unique_id onto the compact-MAC scheme, or None.
+
+    Three legacy shapes are folded in:
+
+    - keyed by the panel's ``deviceName``, which the user can change on
+      the panel and which is not unique across two panels;
+    - keyed by the MAC as the panel spells it, ``a4:d5:c2:6b:b8:59``,
+      where the separators split one identifier into six tokens;
+    - subsystem panels, which concatenated the MAC and the area number
+      without a separator and so were ambiguous for any MAC ending in a
+      digit.
+
+    All become ``<compact mac>-<what>`` / ``subsys-<compact mac>-<area>``.
+    """
+    for prefix in (mac, mac_id, device_name):
+        if not prefix:
+            continue
+
+        if unique_id == prefix:
+            return mac_id
+
+        subsys = f"subsys-{prefix}"
+        if unique_id.startswith(subsys):
+            area = unique_id[len(subsys) :].lstrip("-")
+            if area.isdigit():
+                return f"subsys-{mac_id}-{area}"
+            return None
+
+        if unique_id.startswith(f"{prefix}-"):
+            return f"{mac_id}-{unique_id[len(prefix) + 1 :]}"
+
+    return None
+
+
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, device_name: str | None, mac: str
+) -> None:
+    """Re-key existing registry entries onto the MAC-scoped unique ids.
+
+    Without this an upgrade would orphan every entity and create a
+    duplicate set alongside it, losing history and breaking automations.
+    """
+    registry = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not reg_entry.unique_id:
+            continue
+        new_unique_id = _migrated_unique_id(
+            reg_entry.unique_id, device_name, mac, normalized_mac(mac)
+        )
+        if new_unique_id is None or new_unique_id == reg_entry.unique_id:
+            continue
+        if (
+            existing := registry.async_get_entity_id(
+                reg_entry.domain, DOMAIN, new_unique_id
+            )
+        ) and existing != reg_entry.entity_id:
+            # A previous partial migration already created the target;
+            # drop the stale duplicate rather than fail the setup.
+            _LOGGER.warning(
+                "Removing stale entity %s: %s is already used by %s",
+                reg_entry.entity_id,
+                new_unique_id,
+                existing,
+            )
+            registry.async_remove(reg_entry.entity_id)
+            continue
+        _LOGGER.info(
+            "Migrating unique_id for %s: %s -> %s",
+            reg_entry.entity_id,
+            reg_entry.unique_id,
+            new_unique_id,
+        )
+        registry.async_update_entity(reg_entry.entity_id, new_unique_id=new_unique_id)
+
+
+def _next_available_entity_id(
+    registry: er.EntityRegistry,
+    domain: str,
+    object_id: str,
+    current_entity_id: str,
+) -> str:
+    """Find a free entity_id using HA-style numeric suffixes."""
+    candidate = f"{domain}.{object_id}"
+    if candidate == current_entity_id:
+        return candidate
+
+    suffix = 2
+    while registry.entities.get(candidate) is not None:
+        candidate = f"{domain}.{object_id}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+async def _async_migrate_invalid_entity_ids(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> list[tuple[str, str]]:
+    """Rename entity IDs that are no longer valid object ids.
+
+    Existing installations keep whatever entity_id the registry already
+    holds: only ids Home Assistant would reject (characters outside
+    ``[a-z0-9_]``, such as the ``-`` separators older releases wrote)
+    are rewritten, and the user is told which ones changed.
+    """
+    registry = er.async_get(hass)
+    renames: list[tuple[str, str]] = []
+
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not has_invalid_object_id_chars(reg_entry.entity_id):
+            continue
+        if "." not in reg_entry.entity_id:
+            continue
+
+        domain, object_id = reg_entry.entity_id.split(".", 1)
+        target_object_id = normalized_object_id(object_id, fallback=reg_entry.unique_id)
+        target_entity_id = _next_available_entity_id(
+            registry,
+            domain,
+            target_object_id,
+            reg_entry.entity_id,
+        )
+        if target_entity_id == reg_entry.entity_id:
+            continue
+
+        registry.async_update_entity(
+            reg_entry.entity_id,
+            new_entity_id=target_entity_id,
+        )
+        renames.append((reg_entry.entity_id, target_entity_id))
+        _LOGGER.info(
+            "Migrated invalid entity ID for %s: %s -> %s",
+            DOMAIN,
+            reg_entry.entity_id,
+            target_entity_id,
+        )
+
+    if renames:
+        rename_list = "\n".join(f"- {old} -> {new}" for old, new in renames)
+        persistent_notification.async_create(
+            hass,
+            (
+                "The integration renamed invalid entity IDs so they stay valid "
+                "Home Assistant object ids. Update automations, scripts, scenes, "
+                "and dashboards that reference the old IDs.\n\n"
+                f"{rename_list}"
+            ),
+            title="Hikvision AX Pro entity IDs updated",
+            notification_id=f"{DOMAIN}_entity_id_migration_{entry.entry_id}",
+        )
+
+    return renames
 
 
 def _filter_enabled(n: SubSys) -> bool:
@@ -260,9 +420,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
 
-    migrate_invalid_entity_ids(hass, entry)
+    await _async_migrate_unique_ids(hass, entry, coordinator.device_name, mac)
+    await _async_migrate_invalid_entity_ids(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Second pass: entities created during platform setup (new unique
+    # ids, or entity ids restored from deleted registry entries) can
+    # still carry ids the first pass never saw.
+    await _async_migrate_invalid_entity_ids(hass, entry)
 
     return True
 
@@ -327,6 +493,9 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         self.zone_status = None
         self.host = axpro.host
         self.mac = mac
+        # Compact form used to scope unique ids; ``mac`` stays as the
+        # panel reports it and keys the device registry entries.
+        self.mac_id = normalized_mac(mac)
         self.use_code = use_code
         self.code_format = code_format
         self.use_code_arming = use_code_arming

--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.alarm_control_panel import DOMAIN as PANEL_DOMAIN
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import Arming, HikAxProDataUpdateCoordinator, SubSys
 from .const import ALLOW_SUBSYSTEMS, DATA_COORDINATOR, DOMAIN
+from .entity_id import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +57,14 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
 
     _attr_code_arm_required = False
 
+    def __init__(self, coordinator: HikAxProDataUpdateCoordinator) -> None:
+        """Initialize the panel and pin its entity id."""
+        super().__init__(coordinator=coordinator)
+        self.entity_id = build_entity_id(
+            PANEL_DOMAIN, coordinator.mac_id, coordinator.mac_id,
+            coordinator.device_name,
+        )
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -69,7 +79,7 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
+            identifiers={(DOMAIN, self.coordinator.mac)},
             manufacturer="Hikvision - Ax Pro",
             model=self.coordinator.device_model,
             name=self.coordinator.device_name,
@@ -78,7 +88,7 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     @property
     def unique_id(self):
         """Return a unique id."""
-        return self.coordinator.mac
+        return self.coordinator.mac_id
 
     @property
     def name(self):
@@ -149,6 +159,9 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
         """Initialize subpanel."""
         self.sys = sys
         super().__init__(coordinator=coordinator)
+        self.entity_id = build_entity_id(
+            PANEL_DOMAIN, self.unique_id, coordinator.mac_id, sys.name
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -178,7 +191,7 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
     @property
     def unique_id(self):
         """Return a unique id."""
-        return "subsys-" + self.coordinator.mac + str(self.sys.id)
+        return f"subsys-{self.coordinator.mac_id}-{self.sys.id}"
 
     @property
     def name(self):

--- a/custom_components/hikvision_axpro/binary_sensor.py
+++ b/custom_components/hikvision_axpro/binary_sensor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.binary_sensor import (
-    DOMAIN as SENSOR_DOMAIN,
+    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
@@ -21,8 +21,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HikAxProDataUpdateCoordinator
 from .const import DATA_COORDINATOR, DOMAIN
-from .hik_device import HikDevice
 from .entity_id import build_entity_id
+from .hik_device import HikDevice
 from .model import (
     MOTION_DETECTOR_TYPES,
     DetectorType,
@@ -192,13 +192,13 @@ class HikWirelessExtMagnetDetector(CoordinatorEntity, HikDevice, BinarySensorEnt
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:magnet"
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -251,12 +251,12 @@ class HikMagneticContactDetector(CoordinatorEntity, HikDevice, BinarySensorEntit
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -309,12 +309,12 @@ class HikMagnetShockDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-shock-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-shock-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-shock", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -376,12 +376,12 @@ class HikMagnetOpenDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-open-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-open-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-open", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -443,12 +443,12 @@ class HikMagnetTiltDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-tilt-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-tilt-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-tilt", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -510,12 +510,12 @@ class HikMotionDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-motion-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-motion-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.MOTION
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "motion", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -563,14 +563,14 @@ class HikTamperDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-tamper-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-tamper-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:electric-switch"
         self._attr_device_class = BinarySensorDeviceClass.TAMPER
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "tamper", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -609,14 +609,14 @@ class HikBypassDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-bypass-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-bypass-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:alarm-light-off"
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "bypass", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -655,14 +655,14 @@ class HikArmedInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-armed-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-armed-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:lock"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "armed", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -701,14 +701,14 @@ class HikAlarmInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-alarm-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-alarm-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:alarm-light"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "alarm", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -747,14 +747,14 @@ class HikStayAwayInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-stayaway-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-stayaway-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:shield-lock-outline"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "stayaway", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -793,14 +793,14 @@ class HikIsViaRepeaterInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-isviarepeater-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-isviarepeater-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:google-circles-extended"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "isviarepeater", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -839,14 +839,14 @@ class HikBinaryBatteryInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-battery-low-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-battery-low-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery"
         self._attr_device_class = BinarySensorDeviceClass.BATTERY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "battery-low", zone.id
-        )
 
     @property
     def name(self) -> str | None:

--- a/custom_components/hikvision_axpro/button.py
+++ b/custom_components/hikvision_axpro/button.py
@@ -49,9 +49,9 @@ class HikOneKeyAlarmButton(CoordinatorEntity, ButtonEntity):
         self._attr_has_entity_name = True
         self._attr_name = "One-key alarm"
         self._attr_icon = "mdi:alarm-light"
-        self._attr_unique_id = f"{coordinator.device_name}-one-key-alarm"
+        self._attr_unique_id = f"{coordinator.mac_id}-one-key-alarm"
         self.entity_id = build_entity_id(
-            BUTTON_DOMAIN, coordinator.device_name, "one_key_alarm"
+            BUTTON_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.mac))},
@@ -83,9 +83,9 @@ class HikOneKeyAlarmClearButton(CoordinatorEntity, ButtonEntity):
         self._attr_has_entity_name = True
         self._attr_name = "Clear one-key alarm"
         self._attr_icon = "mdi:alarm-light-off"
-        self._attr_unique_id = f"{coordinator.device_name}-one-key-alarm-clear"
+        self._attr_unique_id = f"{coordinator.mac_id}-one-key-alarm-clear"
         self.entity_id = build_entity_id(
-            BUTTON_DOMAIN, coordinator.device_name, "one_key_alarm_clear"
+            BUTTON_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.mac))},

--- a/custom_components/hikvision_axpro/entity_id.py
+++ b/custom_components/hikvision_axpro/entity_id.py
@@ -1,19 +1,34 @@
-"""Helpers for valid Home Assistant object/entity IDs."""
+"""Helpers for valid, predictable Home Assistant object/entity IDs.
+
+Every entity id is derived from that entity's ``unique_id``, so the two
+never drift apart and the id is unique by construction: no numeric
+``_2`` suffixes appear when two panels carry zones with the same name.
+An underscore only ever separates two distinct pieces of information —
+the panel MAC stays one compact token, and the trailing number is the
+zone (or area, battery, siren…) the entity belongs to::
+
+    a4d5c26bb859-tamper-1  ->  binary_sensor.a4d5c26bb859_tamper_1
+"""
 
 from __future__ import annotations
 
 from hashlib import sha1
-import logging
 import re
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-_LOGGER = logging.getLogger(__name__)
-
 INVALID_OBJECT_ID_RE = re.compile(r"[^a-z0-9_]")
+
+
+def normalized_mac(mac: str | None) -> str:
+    """Return the MAC as one compact token: ``a4d5c26bb859``.
+
+    Separators carry no information here, and spelling the MAC out as
+    ``a4:d5:...`` (or, once slugified, ``a4_d5_...``) turns a single
+    identifier into six. Keeping it compact leaves ``_`` free to
+    separate genuinely different parts of an id.
+    """
+    return re.sub(r"[^a-z0-9]", "", (mac or "").lower())
 
 
 def normalized_object_id(value: str | None, fallback: str | None = None) -> str:
@@ -42,41 +57,65 @@ def has_invalid_object_id_chars(entity_id: str) -> bool:
     return bool(INVALID_OBJECT_ID_RE.search(object_id))
 
 
-def build_entity_id(domain: str, device_name: str | None, *parts: object) -> str:
-    """Build a valid entity_id: ``{domain}.{device}_{suffix}_{id}``.
+def build_entity_id(
+    domain: str,
+    unique_id: str | None,
+    mac_id: str,
+    device_name: str | None = None,
+    number_marker: str = "",
+) -> str:
+    """Build ``<domain>.<device>_z<zone>_<name>_<compact mac>``.
 
-    Example: ``sensor.ax_pro_temperature_0``.
+    The parts come from the entity's own ``unique_id``, which is
+    ``<compact mac>-<name>[-<number>]``, so the id is unique by
+    construction and Home Assistant never has to disambiguate with a
+    ``_2`` suffix when two panels carry zones of the same name.
+
+A zone number is written ``z1`` rather than left bare, so it reads
+    as a zone and can never be mistaken for one of those dedup suffixes.
+    ``number_marker`` is what the number counts, so it is only ``"z"``
+    for entities that really belong to a zone — a hub battery or a relay
+    keeps its own plain number. The number sits next to the device it
+    qualifies and the id ends on the MAC that says which panel::
+
+        ingresso + a4d5c26bb859-tamper-1      (zone)
+            -> binary_sensor.ingresso_z1_tamper_a4d5c26bb859
+        alarm    + a4d5c26bb859-hub-battery-1 (not a zone)
+            -> sensor.alarm_hub_battery_1_a4d5c26bb859
+        alarm    + a4d5c26bb859-ac-power      (nothing numbered)
+            -> binary_sensor.alarm_ac_power_a4d5c26bb859
+
+    Only new entities are affected: Home Assistant keeps whatever
+    entity_id the registry already holds for a known unique_id, so an
+    existing installation — including hand-picked ids — is left as is.
     """
-    object_parts = [normalized_object_id(device_name, fallback="axpro")]
-    for part in parts:
-        if part is None:
-            continue
-        object_parts.append(normalized_object_id(str(part)))
-    return f"{domain}.{'_'.join(object_parts)}"
+    tokens = [t for t in normalized_object_id(unique_id).split("_") if t]
+    mac_token = normalized_object_id(mac_id)
 
+    # Drop the MAC wherever it sits; it is re-appended at the end.
+    rest = [t for t in tokens if t != mac_token]
 
-def migrate_invalid_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Rename registry entries whose object_id is not a valid HA slug."""
-    registry = er.async_get(hass)
-    for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if not has_invalid_object_id_chars(entity.entity_id):
-            continue
+    # A trailing run of digits identifies the zone / area / device.
+    numbers: list[str] = []
+    while rest and rest[-1].isdigit():
+        numbers.insert(0, rest.pop())
 
-        domain, object_id = entity.entity_id.split(".", 1)
-        new_object_id = normalized_object_id(object_id)
-        new_entity_id = f"{domain}.{new_object_id}"
+    device = [t for t in slugify(device_name or "").split("_") if t]
+    # A device already named after what the entity reports would repeat
+    # itself ("front door alarm" + "alarm"); keep the leading copy only.
+    while device and rest and device[-1] == rest[0]:
+        rest.pop(0)
+    # Likewise when the device name already ends in the number, as area
+    # panels do ("Area 1" + area 1): no need to say it twice.
+    while device and numbers and device[-1] == numbers[0]:
+        numbers.pop(0)
 
-        if new_entity_id == entity.entity_id:
-            continue
-
-        if registry.async_get(new_entity_id) is not None:
-            # Avoid clobbering an existing entity; append a short unique suffix.
-            new_entity_id = f"{domain}.{new_object_id}_{entity.unique_id[-6:]}"
-            new_entity_id = (
-                f"{domain}.{normalized_object_id(new_entity_id.split('.', 1)[1])}"
-            )
-
-        _LOGGER.info(
-            "Migrating invalid entity_id %s -> %s", entity.entity_id, new_entity_id
-        )
-        registry.async_update_entity(entity.entity_id, new_entity_id=new_entity_id)
+    if number_marker:
+        # A marked number leads, right after the device it qualifies.
+        parts = [*device, *(f"{number_marker}{n}" for n in numbers), *rest]
+    else:
+        # An unmarked number stays attached to what it counts.
+        parts = [*device, *rest, *numbers]
+    if mac_token:
+        parts.append(mac_token)
+    return f"{domain}.{'_'.join(parts)}"

--- a/custom_components/hikvision_axpro/hik_device.py
+++ b/custom_components/hikvision_axpro/hik_device.py
@@ -6,10 +6,11 @@ Understands zone and custom refID
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
+from .entity_id import build_entity_id
 from .model import Zone
 
 
-class HikDevice:
+class HikDevice():
     """Hik device as base for all sensors from HikVision.
 
     Understands zone and custom refID
@@ -29,3 +30,13 @@ class HikDevice:
             # model="Unknown" if self.zone.model is not "0x00001" else self.zone.model,
             sw_version=self.zone.version,
         )
+
+    @property
+    def _object_id_device_name(self) -> str | None:
+        """Device name to strip, falling back to the zone name.
+
+        The registry device entry is only available once the entity has
+        been added; before that the zone name is the device name this
+        integration asks Home Assistant to create.
+        """
+        return super()._object_id_device_name or self.zone.name

--- a/custom_components/hikvision_axpro/host_entities.py
+++ b/custom_components/hikvision_axpro/host_entities.py
@@ -88,14 +88,14 @@ class HikAcPowerBinary(HikPanelEntity, BinarySensorEntity):
         self, coordinator: HikAxProDataUpdateCoordinator, entry_id: str
     ) -> None:
         super().__init__(coordinator, entry_id)
-        self._attr_unique_id = f"{coordinator.device_name}-ac-power"
+        self._attr_unique_id = f"{coordinator.mac_id}-ac-power"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = "AC power"
         self._attr_has_entity_name = True
         self._attr_device_class = BinarySensorDeviceClass.POWER
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN, coordinator.device_name, "ac_power"
-        )
 
     def _is_on(self) -> bool | None:
         data = self.coordinator.ac_power_status
@@ -127,13 +127,13 @@ class HikHostStatusSensor(HikPanelEntity, SensorEntity):
         self, coordinator: HikAxProDataUpdateCoordinator, entry_id: str
     ) -> None:
         super().__init__(coordinator, entry_id)
-        self._attr_unique_id = f"{coordinator.device_name}-host-status"
+        self._attr_unique_id = f"{coordinator.mac_id}-host-status"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = "Host status"
         self._attr_has_entity_name = True
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "host_status"
-        )
 
     def _value(self) -> str | None:
         data = self.coordinator.host_status
@@ -182,7 +182,10 @@ class HikHubBatteryPercent(HikPanelEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
-        self._attr_unique_id = f"{coordinator.device_name}-hub-battery-{battery_id}"
+        self._attr_unique_id = f"{coordinator.mac_id}-hub-battery-{battery_id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = (
             "Hub battery" if battery_id in (0, 1) else f"Hub battery {battery_id}"
         )
@@ -191,9 +194,6 @@ class HikHubBatteryPercent(HikPanelEntity, SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -221,7 +221,10 @@ class HikHubBatteryStatus(HikPanelEntity, SensorEntity):
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
         self._attr_unique_id = (
-            f"{coordinator.device_name}-hub-battery-status-{battery_id}"
+            f"{coordinator.mac_id}-hub-battery-status-{battery_id}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_name = (
             "Hub battery status"
@@ -230,9 +233,6 @@ class HikHubBatteryStatus(HikPanelEntity, SensorEntity):
         )
         self._attr_has_entity_name = True
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery_status", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -256,7 +256,10 @@ class HikHubBatteryVoltage(HikPanelEntity, SensorEntity):
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
         self._attr_unique_id = (
-            f"{coordinator.device_name}-hub-battery-voltage-{battery_id}"
+            f"{coordinator.mac_id}-hub-battery-voltage-{battery_id}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_name = (
             "Hub battery voltage"
@@ -268,9 +271,6 @@ class HikHubBatteryVoltage(HikPanelEntity, SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery_voltage", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/hikvision_axpro/peripheral_entities.py
+++ b/custom_components/hikvision_axpro/peripheral_entities.py
@@ -362,14 +362,14 @@ class HikPeripheralBinary(CoordinatorEntity, BinarySensorEntity):
         self._device_id = device_id
         self._get = get
         self._value_fn = value_fn
-        self._attr_unique_id = f"{coordinator.device_name}-{kind}-{device_id}-{key}"
+        self._attr_unique_id = f"{coordinator.mac_id}-{kind}-{device_id}-{key}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id
+        )
         self._attr_name = name
         self._attr_has_entity_name = True
         self._attr_device_class = device_class
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN, coordinator.device_name, kind, device_id, key
-        )
 
     def _current(self):
         return self._get(self.coordinator)
@@ -432,7 +432,10 @@ class HikPeripheralSensor(CoordinatorEntity, SensorEntity):
             SensorDeviceClass.TEMPERATURE,
             SensorDeviceClass.SIGNAL_STRENGTH,
         )
-        self._attr_unique_id = f"{coordinator.device_name}-{kind}-{device_id}-{key}"
+        self._attr_unique_id = f"{coordinator.mac_id}-{kind}-{device_id}-{key}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id
+        )
         self._attr_name = name
         self._attr_has_entity_name = True
         if device_class is not None:
@@ -442,9 +445,6 @@ class HikPeripheralSensor(CoordinatorEntity, SensorEntity):
         if state_class is not None:
             self._attr_state_class = state_class
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, kind, device_id, key
-        )
 
     def _current(self):
         return self._get(self.coordinator)

--- a/custom_components/hikvision_axpro/sensor.py
+++ b/custom_components/hikvision_axpro/sensor.py
@@ -27,9 +27,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HikAxProDataUpdateCoordinator
+from .entity_id import build_entity_id
 from .const import DATA_COORDINATOR, DOMAIN
 from .hik_device import HikDevice
-from .entity_id import build_entity_id
 from .model import DetectorType, Status, Zone, zone_device_model
 from .host_entities import build_host_sensors
 from .peripheral_entities import (
@@ -137,15 +137,15 @@ class HikTemperature(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-temp-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-temp-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:thermometer"
         # self._attr_name = f"{self.zone.name} Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "temperature", zone.id
-        )
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
@@ -178,16 +178,16 @@ class HikHumidity(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-humid-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-humid-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:cloud-percent"
         # self._attr_name = f"{self.zone.name} Humidity"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "humidity", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -219,16 +219,16 @@ class HikBatteryInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-battery-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-battery-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery"
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "battery", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -264,13 +264,13 @@ class HikChargeStatus(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-charge-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-charge-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery-heart-variant"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "charge", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -304,16 +304,16 @@ class HikSignalInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-signal-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-signal-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "signal", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -345,11 +345,11 @@ class HikStatusInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-status-{zone.id}"
-        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{self.coordinator.mac_id}-status-{zone.id}"
         self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "status", zone.id
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
         )
+        self._attr_has_entity_name = True
         if (
             self.coordinator.zones
             and self.coordinator.zones[self.zone.id]

--- a/custom_components/hikvision_axpro/siren_entities.py
+++ b/custom_components/hikvision_axpro/siren_entities.py
@@ -268,7 +268,10 @@ class HikSirenBinary(HikSirenEntity, BinarySensorEntity):
         self._key = key
         self._value_fn = value_fn
         self._attr_unique_id = (
-            f"{coordinator.device_name}-siren-{self.siren_id}-{key}"
+            f"{coordinator.mac_id}-siren-{self.siren_id}-{key}"
+        )
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, siren.name
         )
         self._attr_name = name
         self._attr_has_entity_name = True
@@ -276,13 +279,6 @@ class HikSirenBinary(HikSirenEntity, BinarySensorEntity):
             self._attr_device_class = device_class
         if diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN,
-            coordinator.device_name,
-            "siren",
-            self.siren_id,
-            key,
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -330,7 +326,10 @@ class HikSirenSensor(HikSirenEntity, SensorEntity):
             SensorDeviceClass.SIGNAL_STRENGTH,
         )
         self._attr_unique_id = (
-            f"{coordinator.device_name}-siren-{self.siren_id}-{key}"
+            f"{coordinator.mac_id}-siren-{self.siren_id}-{key}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, siren.name
         )
         self._attr_name = name
         self._attr_has_entity_name = True
@@ -342,9 +341,6 @@ class HikSirenSensor(HikSirenEntity, SensorEntity):
             self._attr_state_class = state_class
         if diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "siren", self.siren_id, key
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/hikvision_axpro/switch.py
+++ b/custom_components/hikvision_axpro/switch.py
@@ -10,8 +10,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.components.switch import (
-    SwitchEntity,
     DOMAIN as SWITCH_DOMAIN,
+    SwitchEntity,
     SwitchDeviceClass,
 )
 
@@ -79,9 +79,9 @@ class HikRelaySwitch(CoordinatorEntity, SwitchEntity):
         super().__init__(coordinator)
         self.switch = switch
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-relay-{switch.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-relay-{switch.id}"
         self.entity_id = build_entity_id(
-            SWITCH_DOMAIN, coordinator.device_name, "relay", switch.id
+            SWITCH_DOMAIN, self._attr_unique_id, coordinator.mac_id, switch.name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(self._ref_id) + "-relay-" + str(switch.id))},
@@ -155,14 +155,14 @@ class HikSirenSwitch(CoordinatorEntity, SwitchEntity):
         self._ref_id = entry_id
         siren = coordinator.sirens.get(siren_id)
         name = (siren.name if siren else None) or f"Siren {siren_id}"
-        self._attr_unique_id = f"{coordinator.device_name}-siren-control-{siren_id}"
+        self._attr_unique_id = f"{coordinator.mac_id}-siren-control-{siren_id}"
+        self.entity_id = build_entity_id(
+            SWITCH_DOMAIN, self._attr_unique_id, coordinator.mac_id, name
+        )
         self._attr_name = "Control"
         self._attr_has_entity_name = True
         self._attr_device_class = SwitchDeviceClass.SWITCH
         self._attr_icon = "mdi:alarm-bell"
-        self.entity_id = build_entity_id(
-            SWITCH_DOMAIN, coordinator.device_name, "siren_control", siren_id
-        )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(entry_id) + "-siren-" + str(siren_id))},
             manufacturer="HikVision",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q -p no:pytest-sqlalchemy"
+asyncio_mode = "auto"
 testpaths = [
     "tests",
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,4 @@ hikaxpro==2.3.0
 homeassistant
 xmltodict
 pytest
-
+pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,237 @@
+"""Shared fixtures: a mock AX Pro panel with in-memory state."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.const import (
+    ATTR_CODE_FORMAT,
+    CONF_CODE,
+    CONF_ENABLED,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.hikvision_axpro.const import (
+    ALLOW_SUBSYSTEMS,
+    DATA_COORDINATOR,
+    DOMAIN,
+    USE_CODE_ARMING,
+)
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+DEVICE_INFO_XML = (
+    '<DeviceInfo xmlns="http://www.hikvision.com/ver20/XMLSchema">'
+    "<deviceName>axpro</deviceName><model>AX PRO</model></DeviceInfo>"
+)
+
+
+@pytest.fixture
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Allow loading the custom component.
+
+    Applied via ``pytestmark`` in the integration-level test modules so
+    that the pure-function tests do not pull in the ``hass`` fixture.
+    """
+    yield
+
+
+def zone_payload(
+    zone_id: int = 1,
+    name: str | None = None,
+    status: str = "online",
+    bypassed: bool = False,
+    armed: bool = False,
+    alarm: bool = False,
+    tamper: bool = False,
+    sub_system_no: int = 1,
+    zone_type: str = "Instant",
+    magnet_open: bool | None = None,
+    charge: str | None = None,
+    stay_away: bool | None = None,
+) -> dict:
+    """Build a raw zone status dict as the panel returns it."""
+    payload = {
+        "id": zone_id,
+        "name": name or f"Zone {zone_id}",
+        "status": status,
+        "tamperEvident": tamper,
+        "bypassed": bypassed,
+        "armed": armed,
+        "alarm": alarm,
+        "subSystemNo": sub_system_no,
+        "zoneType": zone_type,
+    }
+    if magnet_open is not None:
+        payload["magnetOpenStatus"] = magnet_open
+    if charge is not None:
+        payload["charge"] = charge
+    if stay_away is not None:
+        payload["stayAway"] = stay_away
+    return payload
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in."""
+
+    def __init__(self, status_code: int = 200, text: str = "", json_data=None):
+        self.status_code = status_code
+        self.text = text or (str(json_data) if json_data is not None else "")
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+
+class MockAxPro:
+    """In-memory AX Pro panel implementing the hikaxpro client API."""
+
+    host = "1.2.3.4"
+
+    def __init__(self, zones: list[dict] | None = None, subsystems=None):
+        self.zones: dict[int, dict] = {z["id"]: z for z in (zones or [])}
+        # Optional per-zone configuration payloads (ZonesConfig endpoint),
+        # e.g. {"id": 1, "zoneName": "Front door"}
+        self.zone_configs: list[dict] = []
+        self.subsystems = subsystems or [
+            {
+                "id": 1,
+                "arming": "disarm",
+                "alarm": False,
+                "enabled": True,
+                "name": "Area 1",
+                "delayTime": 0,
+            }
+        ]
+        self.refuse_arm = False
+        self.zone_status_fail = False
+        self.arm_calls: list[tuple[str, int | None]] = []
+
+    # --- helpers for tests -------------------------------------------------
+    def set_zone(self, zone_id: int, **fields) -> None:
+        self.zones[zone_id].update(fields)
+
+    def area(self, sub_id: int = 1) -> dict:
+        return next(s for s in self.subsystems if s["id"] == sub_id)
+
+    # --- hikaxpro client API ------------------------------------------------
+    def get_interface_mac_address(self, interface_id):
+        return "00:11:22:33:44:55"
+
+    def set_logging_level(self, level):
+        pass
+
+    def connect(self):
+        return True
+
+    @staticmethod
+    def build_url(endpoint, is_json=False):
+        prefix = "&" if "?" in endpoint else "?"
+        return f"{endpoint}{prefix}format=json" if is_json else endpoint
+
+    def subsystem_status(self):
+        return {"SubSysList": [{"SubSys": dict(sub)} for sub in self.subsystems]}
+
+    def zone_status(self):
+        if self.zone_status_fail:
+            raise ConnectionError("zone status unavailable")
+        return {"ZoneList": [{"Zone": dict(zone)} for zone in self.zones.values()]}
+
+    def _arm(self, mode, sub_id):
+        self.arm_calls.append((mode, sub_id))
+        if self.refuse_arm:
+            return False
+        for sub in self.subsystems:
+            if sub_id is None or sub["id"] == sub_id:
+                sub["arming"] = mode
+        return True
+
+    def arm_home(self, sub_id=None):
+        return self._arm("stay", sub_id)
+
+    def arm_away(self, sub_id=None):
+        return self._arm("away", sub_id)
+
+    def disarm(self, sub_id=None):
+        for sub in self.subsystems:
+            if sub_id is None or sub["id"] == sub_id:
+                sub["arming"] = "disarm"
+        return True
+
+    def make_request(self, endpoint, method, data=None, is_json=False):
+        if "control/arm/" in endpoint:
+            # Used by the integration for arm modes hikaxpro does not
+            # expose (vacation).
+            sid = endpoint.split("control/arm/")[1].split("?")[0]
+            sub_id = None if sid == "0xffffffff" else int(sid)
+            ways = endpoint.split("ways=")[1].split("&")[0]
+            if not self._arm(ways, sub_id):
+                return MockResponse(json_data={})
+            return MockResponse(json_data={"statusCode": 1})
+        if "status/zones" in endpoint:
+            if self.zone_status_fail:
+                raise ConnectionError("zone status unavailable")
+            return MockResponse(json_data=self.zone_status())
+        if "deviceInfo" in endpoint:
+            return MockResponse(text=DEVICE_INFO_XML)
+        if "Configuration/zones" in endpoint:
+            return MockResponse(
+                json_data={"List": [{"Zone": dict(cfg)} for cfg in self.zone_configs]}
+            )
+        if "Configuration/outputs" in endpoint:
+            return MockResponse(json_data={"List": []})
+        if "exDevStatus" in endpoint:
+            return MockResponse(json_data={})
+        return MockResponse(status_code=404, text=f"no mock for {endpoint}")
+
+
+@pytest.fixture
+def panel():
+    """A default panel: door zone 1 + PIR zone 2."""
+    mock = MockAxPro(
+        zones=[
+            zone_payload(1, name="Front door", magnet_open=False),
+            zone_payload(2, name="Curtain hall"),
+        ]
+    )
+    with patch("hikaxpro.HikAxPro", return_value=mock):
+        yield mock
+
+
+def make_entry(
+    hass, entry_id: str = "test-entry", **overrides
+) -> MockConfigEntry:
+    """Create and register a config entry with sane defaults."""
+    data = {
+        CONF_HOST: "1.2.3.4",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "secret",
+        CONF_ENABLED: False,
+        ATTR_CODE_FORMAT: "NUMBER",
+        CONF_CODE: "",
+        USE_CODE_ARMING: False,
+        CONF_SCAN_INTERVAL: 30,
+        ALLOW_SUBSYSTEMS: False,
+    }
+    data.update(overrides)
+    entry = MockConfigEntry(domain=DOMAIN, data=data, entry_id=entry_id)
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def setup_entry(hass, **overrides) -> MockConfigEntry:
+    """Set up the integration and wait for it to settle."""
+    entry = make_entry(hass, **overrides)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def get_coordinator(hass, entry):
+    return hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]

--- a/tests/test_entity_id.py
+++ b/tests/test_entity_id.py
@@ -2,68 +2,42 @@
 
 from __future__ import annotations
 
-import importlib.util
 import re
-import sys
-import types
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-COMPONENT = ROOT / "custom_components" / "hikvision_axpro"
+from custom_components.hikvision_axpro.entity_id import (
+    build_entity_id,
+    has_invalid_object_id_chars,
+    normalized_mac,
+    normalized_object_id,
+)
+from custom_components.hikvision_axpro.model import DetectorType, zone_device_model
+
+COMPONENT = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "hikvision_axpro"
+)
+
+PLATFORM_FILES = (
+    "binary_sensor.py",
+    "sensor.py",
+    "switch.py",
+    "button.py",
+    "host_entities.py",
+    "peripheral_entities.py",
+    "siren_entities.py",
+)
+
+MAC = "a4d5c26bb859"
 
 
-def _install_ha_stubs() -> None:
-    """Minimal homeassistant stubs so entity_id can load without full HA."""
-    _ha = types.ModuleType("homeassistant")
-    _ha_config_entries = types.ModuleType("homeassistant.config_entries")
-    _ha_core = types.ModuleType("homeassistant.core")
-    _ha_helpers = types.ModuleType("homeassistant.helpers")
-    _ha_entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
-    _ha_util = types.ModuleType("homeassistant.util")
-
-    def _fake_slugify(text: str) -> str:
-        text = (text or "").lower()
-        text = re.sub(r"[^a-z0-9]+", "_", text)
-        return text.strip("_")
-
-    _ha_util.slugify = _fake_slugify
-    _ha_config_entries.ConfigEntry = object
-    _ha_core.HomeAssistant = object
-    _ha_entity_registry.async_get = MagicMock()
-    _ha_entity_registry.async_entries_for_config_entry = MagicMock(return_value=[])
-    _ha_helpers.entity_registry = _ha_entity_registry
-
-    sys.modules.setdefault("homeassistant", _ha)
-    sys.modules.setdefault("homeassistant.config_entries", _ha_config_entries)
-    sys.modules.setdefault("homeassistant.core", _ha_core)
-    sys.modules.setdefault("homeassistant.helpers", _ha_helpers)
-    sys.modules.setdefault(
-        "homeassistant.helpers.entity_registry", _ha_entity_registry
-    )
-    sys.modules.setdefault("homeassistant.util", _ha_util)
-
-
-def _load_module(name: str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_install_ha_stubs()
-entity_id = _load_module("hikvision_axpro_entity_id", COMPONENT / "entity_id.py")
-model = _load_module("hikvision_axpro_model", COMPONENT / "model.py")
-
-build_entity_id = entity_id.build_entity_id
-has_invalid_object_id_chars = entity_id.has_invalid_object_id_chars
-normalized_object_id = entity_id.normalized_object_id
-DetectorType = model.DetectorType
-zone_device_model = model.zone_device_model
+def test_normalized_mac_is_one_compact_token() -> None:
+    """A MAC is one identifier, so it stays one token."""
+    assert normalized_mac("A4:D5:C2:6B:B8:59") == MAC
+    assert normalized_mac("a4-d5-c2-6b-b8-59") == MAC
+    assert normalized_mac(MAC) == MAC
+    assert normalized_mac(None) == ""
 
 
 def test_normalized_object_id_slugifies() -> None:
@@ -72,10 +46,14 @@ def test_normalized_object_id_slugifies() -> None:
     assert re.fullmatch(r"[a-z0-9_]+", normalized_object_id("Český ***", "Zone 7"))
 
 
-def test_normalized_object_id_fallback_hash() -> None:
-    result = normalized_object_id("***", fallback="")
+def test_normalized_object_id_falls_back_then_hashes() -> None:
+    assert normalized_object_id("", fallback="Zone 7") == "zone_7"
+
+    # Nothing sluggable at all: a deterministic id rather than an empty one.
+    result = normalized_object_id("", fallback="")
     assert result.startswith("entity_")
     assert re.fullmatch(r"[a-z0-9_]+", result)
+    assert normalized_object_id("", fallback="") == result
 
 
 def test_has_invalid_object_id_chars() -> None:
@@ -84,15 +62,95 @@ def test_has_invalid_object_id_chars() -> None:
     assert not has_invalid_object_id_chars("sensor.ax_pro_temperature_0")
 
 
-def test_build_entity_id_shape() -> None:
+def test_build_entity_id_is_device_zone_name_mac() -> None:
+    """``<device>_z<zone>_<name>_<compact mac>`` for zone entities."""
     assert (
-        build_entity_id("sensor", "AX PRO", "temperature", 0)
-        == "sensor.ax_pro_temperature_0"
+        build_entity_id("binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z")
+        == "binary_sensor.ingresso_z1_tamper_a4d5c26bb859"
     )
     assert (
-        build_entity_id("binary_sensor", "AX PRO", "magnet-shock", 8)
-        == "binary_sensor.ax_pro_magnet_shock_8"
+        build_entity_id("binary_sensor", f"{MAC}-magnet-shock-8", MAC, "garage", "z")
+        == "binary_sensor.garage_z8_magnet_shock_a4d5c26bb859"
     )
+    assert (
+        build_entity_id("sensor", f"{MAC}-temp-12", MAC, "cucina_tenda", "z")
+        == "sensor.cucina_tenda_z12_temp_a4d5c26bb859"
+    )
+
+
+def test_only_real_zone_numbers_are_marked_with_z() -> None:
+    """A hub battery or a relay is not a zone, so it keeps a plain number."""
+    assert (
+        build_entity_id("sensor", f"{MAC}-hub-battery-1", MAC, "alarm")
+        == "sensor.alarm_hub_battery_1_a4d5c26bb859"
+    )
+    assert (
+        build_entity_id("switch", f"{MAC}-relay-2", MAC, "garage door")
+        == "switch.garage_door_relay_2_a4d5c26bb859"
+    )
+
+
+def test_zone_number_is_marked_so_it_cannot_read_as_a_dedup_suffix() -> None:
+    """``z1`` rather than a bare trailing ``_1``."""
+    entity_id = build_entity_id(
+        "binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z"
+    )
+    assert "_z1_" in entity_id
+    # The MAC always closes the id, so nothing can trail as a suffix.
+    assert entity_id.endswith(MAC)
+    assert not re.search(r"_\d+$", entity_id)
+
+
+def test_build_entity_id_does_not_repeat_the_device_name() -> None:
+    """A device already saying it is not made to say it twice."""
+    assert (
+        build_entity_id(
+            "binary_sensor", f"{MAC}-alarm-1", MAC, "Front door alarm", "z"
+        )
+        == "binary_sensor.front_door_alarm_z1_a4d5c26bb859"
+    )
+    # An area panel whose name already ends in its own number.
+    assert (
+        build_entity_id("alarm_control_panel", f"subsys-{MAC}-1", MAC, "Area 1")
+        == "alarm_control_panel.area_1_subsys_a4d5c26bb859"
+    )
+
+
+def test_build_entity_id_without_a_zone_number() -> None:
+    """Panel-level entities simply have no zone marker."""
+    assert (
+        build_entity_id("binary_sensor", f"{MAC}-ac-power", MAC, "alarm")
+        == "binary_sensor.alarm_ac_power_a4d5c26bb859"
+    )
+    assert (
+        build_entity_id("binary_sensor", f"{MAC}-ready-to-arm-away", MAC, "alarm")
+        == "binary_sensor.alarm_ready_to_arm_away_a4d5c26bb859"
+    )
+    # The panel entity's unique_id is the MAC alone.
+    assert build_entity_id("alarm_control_panel", MAC, MAC, "alarm") == (
+        "alarm_control_panel.alarm_a4d5c26bb859"
+    )
+
+
+def test_build_entity_id_never_needs_a_dedup_suffix() -> None:
+    """Two panels with identically named zones still get distinct ids."""
+    other = "a4d5c26bb85a"
+    first = build_entity_id("binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z")
+    second = build_entity_id(
+        "binary_sensor", f"{other}-tamper-1", other, "ingresso", "z"
+    )
+    assert first != second
+    assert not first.endswith("_2") and not second.endswith("_2")
+
+
+def test_generated_ids_use_underscore_only_as_separator() -> None:
+    for unique_id in (f"{MAC}-tamper-1", f"{MAC}-magnet-shock-8", f"{MAC}-ac-power"):
+        _, object_id = build_entity_id(
+            "sensor", unique_id, MAC, "ingresso", "z"
+        ).split(".", 1)
+        assert re.fullmatch(r"[a-z0-9]+(_[a-z0-9]+)*", object_id)
+        # The MAC stays one token instead of becoming six.
+        assert MAC in object_id
 
 
 def test_zone_device_model_always_str() -> None:
@@ -105,14 +163,17 @@ def test_zone_device_model_always_str() -> None:
     assert zone_device_model(None, None) == "Unknown"
 
 
-@pytest.mark.parametrize(
-    "filename",
-    ("binary_sensor.py", "sensor.py", "switch.py"),
-)
-def test_platforms_do_not_assign_raw_device_name_entity_id(filename: str) -> None:
+@pytest.mark.parametrize("filename", PLATFORM_FILES)
+def test_platforms_derive_entity_id_from_unique_id(filename: str) -> None:
+    """No platform hand-rolls an entity id from a name."""
     content = (COMPONENT / filename).read_text(encoding="utf-8")
     assert "build_entity_id(" in content
-    assert not re.search(
-        r'self\.entity_id\s*=\s*f?["\'].*coordinator\.device_name',
-        content,
-    )
+    assert not re.search(r'self\.entity_id\s*=\s*f?["\']', content)
+
+
+@pytest.mark.parametrize("filename", PLATFORM_FILES)
+def test_unique_ids_are_compact_mac_scoped(filename: str) -> None:
+    """unique_ids key off the compact MAC, not the panel name."""
+    content = (COMPONENT / filename).read_text(encoding="utf-8")
+    assert "device_name}-" not in content
+    assert "coordinator.mac}-" not in content

--- a/tests/test_entity_id_migration.py
+++ b/tests/test_entity_id_migration.py
@@ -1,0 +1,364 @@
+"""Integration-level tests for entity ID generation and migration."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.helpers import entity_registry as er
+
+import custom_components.hikvision_axpro as integration_init
+from custom_components.hikvision_axpro.const import DOMAIN
+
+from .conftest import MockAxPro, make_entry, setup_entry, zone_payload
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+
+def entity_id_of(hass, domain: str, unique_id: str) -> str:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
+    assert entity_id, f"entity {unique_id} not found"
+    return entity_id
+
+
+async def test_generated_ids_use_underscore_only_as_separator(hass, panel):
+    """Generated ids are ``<device>_<what>`` slugs, never MAC soup."""
+    await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    entries = [
+        reg
+        for reg in registry.entities.values()
+        if reg.platform == DOMAIN and reg.unique_id
+    ]
+    assert entries, "no entities were created"
+
+    for reg in entries:
+        _, object_id = reg.entity_id.split(".", 1)
+        assert re.fullmatch(r"[a-z0-9]+(_[a-z0-9]+)*", object_id), reg.entity_id
+        # The MAC is an internal identifier: it must never leak into an id.
+        assert "00_11_22" not in object_id
+
+
+async def test_entity_ids_are_device_zone_name_mac(hass, panel):
+    """``<device>_z<zone>_<name>_<compact mac>``."""
+    await setup_entry(hass)
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.front_door_z1_tamper_001122334455"
+    )
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-armed-1")
+        == "binary_sensor.front_door_z1_armed_001122334455"
+    )
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-bypass-2")
+        == "binary_sensor.curtain_hall_z2_bypass_001122334455"
+    )
+    # Panel-level entities carry the panel name and no zone number.
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "001122334455")
+        == "alarm_control_panel.axpro_001122334455"
+    )
+
+
+async def test_same_zone_name_never_needs_a_dedup_suffix(hass, panel):
+    """Two zones sharing a name stay distinct through the MAC and zone id."""
+    panel.zones[1]["name"] = "Front door alarm"
+    panel.zones[2]["name"] = "Front door alarm"  # same name as zone 1
+    await setup_entry(hass)
+
+    first = entity_id_of(hass, "binary_sensor", "001122334455-alarm-1")
+    second = entity_id_of(hass, "binary_sensor", "001122334455-alarm-2")
+    # The device name already ends in "alarm", so it is not repeated,
+    # and the zone number is marked with "z" rather than trailing bare.
+    assert first == "binary_sensor.front_door_alarm_z1_001122334455"
+    assert second == "binary_sensor.front_door_alarm_z2_001122334455"
+    # Identical zone names, yet no Home Assistant dedup suffix was added.
+    assert not first.endswith("_2") and not second.endswith("_2")
+
+
+async def test_migration_renames_invalid_registry_id_and_is_idempotent(
+    hass, panel, monkeypatch
+):
+    """Invalid ids are renamed in place; a second run changes nothing."""
+    entry = await setup_entry(hass)
+    old_entity_id = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+
+    # HA no longer accepts writing invalid ids directly; emulate a legacy
+    # invalid entry by forcing the migration logic onto this entity.
+    monkeypatch.setattr(
+        integration_init,
+        "has_invalid_object_id_chars",
+        lambda entity_id: entity_id == old_entity_id,
+    )
+    monkeypatch.setattr(
+        integration_init,
+        "normalized_object_id",
+        lambda value, fallback=None: "front_door_tamper_fixed",
+    )
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == "binary_sensor.front_door_tamper_fixed"
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_id_of(hass, "binary_sensor", "001122334455-tamper-1") == migrated
+
+
+async def test_migration_collision_falls_back_with_suffix(hass, panel, monkeypatch):
+    """Collisions get a numeric suffix instead of failing setup."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    tamper = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    armed = entity_id_of(hass, "binary_sensor", "001122334455-armed-1")
+
+    registry.async_update_entity(armed, new_entity_id="binary_sensor.taken_slug")
+    registry.async_update_entity(tamper, new_entity_id="binary_sensor.needs_migration")
+
+    monkeypatch.setattr(
+        integration_init,
+        "has_invalid_object_id_chars",
+        lambda entity_id: entity_id == "binary_sensor.needs_migration",
+    )
+    monkeypatch.setattr(
+        integration_init,
+        "normalized_object_id",
+        lambda value, fallback=None: "taken_slug",
+    )
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.taken_slug_2"
+    )
+
+
+async def test_migration_leaves_existing_valid_ids_untouched(hass, panel):
+    """Upgrading an existing installation does not rename anything valid."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    before = {
+        reg.unique_id: reg.entity_id
+        for reg in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if reg.unique_id
+    }
+    assert before
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    after = {
+        reg.unique_id: reg.entity_id
+        for reg in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if reg.unique_id
+    }
+    assert before == after
+
+
+async def test_legacy_device_name_unique_ids_are_rekeyed_to_the_mac(hass, panel):
+    """An install keyed by deviceName keeps its entities after the upgrade."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "axpro-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+    registry.async_update_entity(legacy.entity_id, name="My tamper")
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Re-keyed in place: same registry row, so name and history survive.
+    assert registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "axpro-tamper-1"
+    ) is None
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == legacy.entity_id
+    assert registry.async_get(migrated).name == "My tamper"
+
+
+async def test_legacy_subsystem_unique_id_gets_a_separator(hass):
+    """``subsys-<mac><area>`` is ambiguous and becomes ``subsys-<mac>-<area>``."""
+    mock = MockAxPro(zones=[zone_payload(1, name="Front door", magnet_open=False)])
+    registry = er.async_get(hass)
+
+    with patch("hikaxpro.HikAxPro", return_value=mock):
+        entry = make_entry(hass, allow_subsystems=True)
+        registry.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            "subsys-00:11:22:33:44:551",
+            config_entry=entry,
+            suggested_object_id="area_1",
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "alarm_control_panel", DOMAIN, "subsys-00:11:22:33:44:551"
+        )
+        is None
+    )
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "subsys-001122334455-1")
+        == "alarm_control_panel.area_1"
+    )
+
+
+async def test_unique_id_migration_drops_a_duplicate_instead_of_failing(hass, panel):
+    """A half-migrated registry does not break setup."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "axpro-tamper-1",
+        config_entry=entry,
+        suggested_object_id="stale_tamper",
+    )
+    already_migrated = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "001122334455-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get("binary_sensor.stale_tamper") is None
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == already_migrated.entity_id
+    )
+
+
+async def test_user_renamed_entity_id_survives_setup(hass, panel):
+    """A user-chosen entity_id is never overwritten by the generator."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    tamper = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    registry.async_update_entity(tamper, new_entity_id="binary_sensor.my_own_name")
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.my_own_name"
+    )
+
+
+async def test_colon_mac_unique_ids_are_compacted(hass, panel):
+    """``a4:d5:...-tamper-1`` becomes ``a4d5...-tamper-1`` in place."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "00:11:22:33:44:55-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+    registry.async_update_entity(legacy.entity_id, name="My tamper")
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, "00:11:22:33:44:55-tamper-1"
+        )
+        is None
+    )
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == legacy.entity_id
+    assert registry.async_get(migrated).name == "My tamper"
+
+
+async def test_colon_mac_panel_unique_id_is_compacted(hass, panel):
+    """The panel entity was keyed by the bare MAC; it is compacted too."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "alarm_control_panel",
+        DOMAIN,
+        "00:11:22:33:44:55",
+        config_entry=entry,
+        suggested_object_id="villa_1_alarm",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "alarm_control_panel", DOMAIN, "00:11:22:33:44:55"
+        )
+        is None
+    )
+    # The hand-picked entity_id survives the re-key.
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "001122334455")
+        == legacy.entity_id
+        == "alarm_control_panel.villa_1_alarm"
+    )
+
+
+async def test_two_panels_with_identical_zone_names(hass):
+    """The reason the MAC is in the id: two panels, same zone names."""
+    names = ["ingresso", "bagno_pt", "cucina"]
+    registry = er.async_get(hass)
+
+    for entry_id, mac in (
+        ("panel-a", "a4:d5:c2:6b:b8:59"),
+        ("panel-b", "a4:d5:c2:6b:b8:5a"),
+    ):
+        mock = MockAxPro(
+            zones=[zone_payload(i, name=n) for i, n in enumerate(names, start=1)]
+        )
+        mock.get_interface_mac_address = lambda _iface, _mac=mac: _mac
+        with patch("hikaxpro.HikAxPro", return_value=mock):
+            entry = make_entry(hass, entry_id=entry_id)
+            assert await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+    rows = [
+        reg
+        for reg in registry.entities.values()
+        if reg.platform == DOMAIN and "-tamper-" in reg.unique_id
+    ]
+    # Nothing dropped by a unique_id collision: 3 zones x 2 panels.
+    assert len(rows) == 6
+    assert len({reg.unique_id for reg in rows}) == 6
+
+    entity_ids = {reg.entity_id for reg in rows}
+    assert len(entity_ids) == 6
+    assert entity_ids == {
+        "binary_sensor.ingresso_z1_tamper_a4d5c26bb859",
+        "binary_sensor.ingresso_z1_tamper_a4d5c26bb85a",
+        "binary_sensor.bagno_pt_z2_tamper_a4d5c26bb859",
+        "binary_sensor.bagno_pt_z2_tamper_a4d5c26bb85a",
+        "binary_sensor.cucina_z3_tamper_a4d5c26bb859",
+        "binary_sensor.cucina_z3_tamper_a4d5c26bb85a",
+    }


### PR DESCRIPTION
### Problem

`unique_id` was keyed off the panel's `deviceName`, which is editable and not unique. Two panels shipping with the default name `alarm` both produce `alarm-tamper-1`, so HA drops the second panel's entities as duplicates. Renaming the panel orphans everything.

Entity IDs were written directly by each entity from a slugified MAC, so every pair of hex digits became a token — `sensor.aa_bb_cc_dd_ee_ff_charge_1` — and only some platforms did it, leaving the integration inconsistent with itself.

### Change

`unique_id` is now MAC-keyed with the MAC as one compact token (`a4d5c26bb859-tamper-1`); subsystem panels gain the separator they lacked (`subsys-{mac}{area}` was ambiguous for a MAC ending in a digit). Entity IDs are derived from the `unique_id` so the two cannot drift:

```
binary_sensor.ingresso_z1_tamper_a4d5c26bb859
sensor.alarm_hub_battery_1_a4d5c26bb859
```

Unique by construction, so identically-named zones on two panels never collide and HA never appends a `_2`. The zone is written `z1` so it can't be read as one of those suffixes; only real zone numbers get the marker.

### Migration

Legacy unique IDs (both the `deviceName` and colon-MAC forms) are re-keyed on the same registry rows, so names, hand-picked entity IDs, history and automations survive. Entity IDs are rewritten only when no longer valid, with a notification listing any renames.

Covered by `test_entity_id.py` / `test_entity_id_migration.py`, including the two-panel case. Suite green (51 tests).

Prerequisite for #207 