### PR TITLE
feat: add managed zone bypass workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .DS_Store
 test_payloads/
 __pycache__/
+.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,29 @@
 # Changelog
 
 ## Unreleased
+- **feat**: managed zone bypass workflow. Which zones may be auto-bypassed is
+  now chosen on the integration itself (**Configure**): one zone picker per
+  arming mode, shown for the modes that have auto-bypass enabled. Each zone
+  exposes a read-only `binary_sensor` per mode reporting whether it is set as
+  bypassable, replacing the former per-zone switch.
+- **feat**: the arming flow re-reads zone states from the panel, bypasses the
+  selected faulted zones, aborts with the offending zone list otherwise, and
+  rolls back on a partial failure. Bypasses applied by the integration are
+  tracked across restarts, removed once a zone recovers while armed, cleaned
+  up on disarm, and reconciled when removed on the panel side.
+- **fix**: the zone picker only offers zones that can really be bypassed — a zone
+  whose type is not eligible, or whose panel-side "forbid bypass on arming" is on,
+  is left out instead of being offered and then silently ignored.
+- **feat**: the first options page now reads "Next" instead of "Submit" when a
+  zone-picker page follows, and says so in its description.
+- **feat**: `unbypass_zone` and `clear_all_bypasses` services, per-mode
+  `ready_to_arm` sensors, vacation arming, and `bypass_applied` /
+  `bypass_removed` / `arming_blocked` events.
+- **feat**: `arm_away_with_bypass` / `arm_home_with_bypass` now really force
+  the bypass flow for that call, instead of silently doing a plain arm.
+- **chore**: the bypass store keeps only what it must — the bypasses this
+  integration applied. An unreadable or unexpected store file is discarded
+  instead of failing the setup, since the reconciliation rebuilds it.
 - **chore**: rework ID generation. Entity IDs are now
   `<device>_z<zone>_<name>_<compact mac>`
   (`binary_sensor.ingresso_z1_tamper_a4d5c26bb859`), derived from the entity's own

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+- **chore**: rework ID generation. Entity IDs are now
+  `<device>_z<zone>_<name>_<compact mac>`
+  (`binary_sensor.ingresso_z1_tamper_a4d5c26bb859`), derived from the entity's own
+  `unique_id`. The MAC stays one compact token instead of being split into six
+  (`a4_d5_c2_...`), so an underscore only ever separates two distinct pieces of
+  information. The id is unique by construction, so two panels carrying zones with
+  the same name no longer collide and Home Assistant never appends a `_2` suffix;
+  a zone number is written `z1` and the MAC always closes the id, so nothing in an
+  ID can be mistaken for such a suffix. Only numbers that really are zones are
+  marked — a hub battery or relay keeps its own plain number.
+- **chore**: key `unique_id` off the compact panel MAC (`a4d5c26bb859-tamper-1`)
+  instead of the panel's `deviceName`, which the user can change on the panel and
+  which is not unique across two panels — with two panels it silently dropped one
+  panel's entities. Subsystem panels gain the missing separator
+  (`subsys-<mac>-<area>`).
+- **chore**: migrate existing installations in place — legacy unique IDs, in both
+  the `deviceName` and the colon-MAC form, are re-keyed on the same registry rows,
+  so custom names, hand-picked entity IDs, history and automations all survive.
+  Entity IDs are only rewritten when they are no longer valid object IDs.
+
 ## v3.4.0
 - **feat**: PIR / motion detector zones expose `binary_sensor` Motion (`device_class: motion`) from zone status `trigger` (#170)
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,62 @@ Example screens of integration.
 ![Main System Device](https://user-images.githubusercontent.com/9423543/224548626-823a6cfa-5c15-4a6a-97d2-32831797253c.png)
 
 
+## Zone bypass & auto-bypass on arming
+
+Opt-in. The panel refuses to arm while a zone is open, offline or tampered;
+this feature can bypass such zones for you, and put them back afterwards.
+
+### Setting it up
+
+Everything is configured on the integration itself
+(**Settings → Devices & services → Hikvision AX Pro → Configure**):
+
+1. **Arming modes with automatic bypass** — pick the arming modes the feature
+   applies to (home / away / vacation). Leaving this empty disables it.
+2. A second page then shows **one zone picker per enabled mode**. Choose the
+   zones the integration may bypass for that mode; each mode has its own list.
+
+Only *instant* zones can be picked: the panel offers its "forbid bypass on
+arming" setting exclusively for that type, so no other type is ever bypassed
+automatically. A zone for which the panel forbids bypassing is ignored even
+when it is selected — the panel-side setting always wins.
+
+### What it does at arming time
+
+1. Zone states are re-read from the panel (never from the poll cache).
+2. A faulted zone that is selected for the mode is bypassed; a faulted zone
+   that is not is reported and **arming is aborted** with the list of zones.
+3. If a bypass fails, the ones already applied in that flow are rolled back
+   and arming is aborted.
+4. While armed, a bypassed zone that recovers and stays healthy for the
+   configured debounce is un-bypassed automatically.
+5. On disarm, every bypass the integration applied is removed. Bypasses
+   applied from the app or keypad are left alone unless
+   *"On disarm, remove all bypasses"* is enabled.
+
+Bypasses applied by the integration are tracked across restarts, and are
+reconciled with the panel if they are removed elsewhere.
+
+### Entities
+
+| Entity | Meaning |
+| --- | --- |
+| `binary_sensor.<zone>_bypass` | The zone is currently bypassed on the panel. Attributes say whether the integration or someone else applied it. |
+| `binary_sensor.<zone>_bypassable_on_<mode>_arming` | Read-only: the zone is selected for that mode *and* the panel allows bypassing it. One per enabled mode. |
+| `binary_sensor.<panel>_ready_to_arm_<mode>` | Advisory: arming in that mode would currently succeed. Attributes list the blocking zones and the zones that would be bypassed. |
+
+### Services
+
+| Service | Description |
+| --- | --- |
+| `hikvision_axpro.bypass_zone` | Bypass one or more zones (target their bypass sensor, or pass `zone_id`). |
+| `hikvision_axpro.unbypass_zone` | Remove the bypass again. `recover_bypass_zone` is a deprecated alias. |
+| `hikvision_axpro.clear_all_bypasses` | Remove every bypass, whoever applied it. Target an area panel to limit it to that area. |
+| `hikvision_axpro.arm_away_with_bypass` / `arm_home_with_bypass` | Run the bypass flow for this call even when the mode has auto-bypass switched off. The zone selection still applies. |
+
+Events `hikvision_axpro_bypass_applied`, `hikvision_axpro_bypass_removed` and
+`hikvision_axpro_arming_blocked` are fired for automations.
+
 ## Installation
 
 ### Pre-check
@@ -119,7 +175,8 @@ Check your batteries for devices. Check that all zones are closed / not triggere
 If you use Hik-Connect app - you can press the **diagnosis** button on the "system overview page".
 It will tell you why you cannot arm the system. 
 
-This integration is not bypassing any "zones" so you might have to set it up via "Hik-Connect" / Web interface.
+You can also let the integration bypass the offending zones for you: see
+[Zone bypass & auto-bypass on arming](#zone-bypass--auto-bypass-on-arming).
 
 ### Everything seems fine I can arm in "Hik-Connect" app but not in HA.
 

--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -9,6 +9,7 @@ import logging
 import hikaxpro
 import xmltodict
 
+from homeassistant.components import persistent_notification
 from homeassistant.components.alarm_control_panel import (
     SCAN_INTERVAL,
     AlarmControlPanelState,
@@ -42,7 +43,11 @@ from .const import (
     ENABLE_DEBUG_OUTPUT,
     USE_CODE_ARMING,
 )
-from .entity_id import migrate_invalid_entity_ids
+from .entity_id import (
+    has_invalid_object_id_chars,
+    normalized_mac,
+    normalized_object_id,
+)
 from .model import (
     Arming,
     ExDevStatusResponse,
@@ -72,6 +77,161 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 _LOGGER = logging.getLogger(__name__)
+
+
+def _migrated_unique_id(
+    unique_id: str, device_name: str | None, mac: str, mac_id: str
+) -> str | None:
+    """Map a legacy unique_id onto the compact-MAC scheme, or None.
+
+    Three legacy shapes are folded in:
+
+    - keyed by the panel's ``deviceName``, which the user can change on
+      the panel and which is not unique across two panels;
+    - keyed by the MAC as the panel spells it, ``a4:d5:c2:6b:b8:59``,
+      where the separators split one identifier into six tokens;
+    - subsystem panels, which concatenated the MAC and the area number
+      without a separator and so were ambiguous for any MAC ending in a
+      digit.
+
+    All become ``<compact mac>-<what>`` / ``subsys-<compact mac>-<area>``.
+    """
+    for prefix in (mac, mac_id, device_name):
+        if not prefix:
+            continue
+
+        if unique_id == prefix:
+            return mac_id
+
+        subsys = f"subsys-{prefix}"
+        if unique_id.startswith(subsys):
+            area = unique_id[len(subsys) :].lstrip("-")
+            if area.isdigit():
+                return f"subsys-{mac_id}-{area}"
+            return None
+
+        if unique_id.startswith(f"{prefix}-"):
+            return f"{mac_id}-{unique_id[len(prefix) + 1 :]}"
+
+    return None
+
+
+async def _async_migrate_unique_ids(
+    hass: HomeAssistant, entry: ConfigEntry, device_name: str | None, mac: str
+) -> None:
+    """Re-key existing registry entries onto the MAC-scoped unique ids.
+
+    Without this an upgrade would orphan every entity and create a
+    duplicate set alongside it, losing history and breaking automations.
+    """
+    registry = er.async_get(hass)
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not reg_entry.unique_id:
+            continue
+        new_unique_id = _migrated_unique_id(
+            reg_entry.unique_id, device_name, mac, normalized_mac(mac)
+        )
+        if new_unique_id is None or new_unique_id == reg_entry.unique_id:
+            continue
+        if (
+            existing := registry.async_get_entity_id(
+                reg_entry.domain, DOMAIN, new_unique_id
+            )
+        ) and existing != reg_entry.entity_id:
+            # A previous partial migration already created the target;
+            # drop the stale duplicate rather than fail the setup.
+            _LOGGER.warning(
+                "Removing stale entity %s: %s is already used by %s",
+                reg_entry.entity_id,
+                new_unique_id,
+                existing,
+            )
+            registry.async_remove(reg_entry.entity_id)
+            continue
+        _LOGGER.info(
+            "Migrating unique_id for %s: %s -> %s",
+            reg_entry.entity_id,
+            reg_entry.unique_id,
+            new_unique_id,
+        )
+        registry.async_update_entity(reg_entry.entity_id, new_unique_id=new_unique_id)
+
+
+def _next_available_entity_id(
+    registry: er.EntityRegistry,
+    domain: str,
+    object_id: str,
+    current_entity_id: str,
+) -> str:
+    """Find a free entity_id using HA-style numeric suffixes."""
+    candidate = f"{domain}.{object_id}"
+    if candidate == current_entity_id:
+        return candidate
+
+    suffix = 2
+    while registry.entities.get(candidate) is not None:
+        candidate = f"{domain}.{object_id}_{suffix}"
+        suffix += 1
+    return candidate
+
+
+async def _async_migrate_invalid_entity_ids(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> list[tuple[str, str]]:
+    """Rename entity IDs that are no longer valid object ids.
+
+    Existing installations keep whatever entity_id the registry already
+    holds: only ids Home Assistant would reject (characters outside
+    ``[a-z0-9_]``, such as the ``-`` separators older releases wrote)
+    are rewritten, and the user is told which ones changed.
+    """
+    registry = er.async_get(hass)
+    renames: list[tuple[str, str]] = []
+
+    for reg_entry in er.async_entries_for_config_entry(registry, entry.entry_id):
+        if not has_invalid_object_id_chars(reg_entry.entity_id):
+            continue
+        if "." not in reg_entry.entity_id:
+            continue
+
+        domain, object_id = reg_entry.entity_id.split(".", 1)
+        target_object_id = normalized_object_id(object_id, fallback=reg_entry.unique_id)
+        target_entity_id = _next_available_entity_id(
+            registry,
+            domain,
+            target_object_id,
+            reg_entry.entity_id,
+        )
+        if target_entity_id == reg_entry.entity_id:
+            continue
+
+        registry.async_update_entity(
+            reg_entry.entity_id,
+            new_entity_id=target_entity_id,
+        )
+        renames.append((reg_entry.entity_id, target_entity_id))
+        _LOGGER.info(
+            "Migrated invalid entity ID for %s: %s -> %s",
+            DOMAIN,
+            reg_entry.entity_id,
+            target_entity_id,
+        )
+
+    if renames:
+        rename_list = "\n".join(f"- {old} -> {new}" for old, new in renames)
+        persistent_notification.async_create(
+            hass,
+            (
+                "The integration renamed invalid entity IDs so they stay valid "
+                "Home Assistant object ids. Update automations, scripts, scenes, "
+                "and dashboards that reference the old IDs.\n\n"
+                f"{rename_list}"
+            ),
+            title="Hikvision AX Pro entity IDs updated",
+            notification_id=f"{DOMAIN}_entity_id_migration_{entry.entry_id}",
+        )
+
+    return renames
 
 
 def _filter_enabled(n: SubSys) -> bool:
@@ -260,9 +420,15 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
 
-    migrate_invalid_entity_ids(hass, entry)
+    await _async_migrate_unique_ids(hass, entry, coordinator.device_name, mac)
+    await _async_migrate_invalid_entity_ids(hass, entry)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
+
+    # Second pass: entities created during platform setup (new unique
+    # ids, or entity ids restored from deleted registry entries) can
+    # still carry ids the first pass never saw.
+    await _async_migrate_invalid_entity_ids(hass, entry)
 
     return True
 
@@ -327,6 +493,9 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         self.zone_status = None
         self.host = axpro.host
         self.mac = mac
+        # Compact form used to scope unique ids; ``mac`` stays as the
+        # panel reports it and keys the device registry entries.
+        self.mac_id = normalized_mac(mac)
         self.use_code = use_code
         self.code_format = code_format
         self.use_code_arming = use_code_arming

--- a/custom_components/hikvision_axpro/__init__.py
+++ b/custom_components/hikvision_axpro/__init__.py
@@ -3,8 +3,9 @@
 import asyncio
 from asyncio import timeout
 import contextlib
-from datetime import timedelta
+from datetime import datetime, timedelta
 import logging
+import re
 
 import hikaxpro
 import xmltodict
@@ -29,25 +30,39 @@ from homeassistant.const import (
     Platform,
 )
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 import homeassistant.helpers.device_registry as dr
 import homeassistant.helpers.entity_registry as er
+from homeassistant.helpers import issue_registry as ir
 from homeassistant.helpers.service import async_register_admin_service
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
+from homeassistant.util import dt as dt_util
 
+from .bypass_manager import BypassManager
+from .bypass_store import BypassStore
 from .const import (
     ALLOW_SUBSYSTEMS,
-    AUTO_BYPASS_ON_ARM,
+    ARM_MODE_AWAY,
+    ARM_MODE_HOME,
+    ARM_MODE_VACATION,
+    CONF_AUTO_BYPASS_MODES,
+    DATA_BYPASS_MANAGER,
     DATA_COORDINATOR,
     DOMAIN,
     ENABLE_DEBUG_OUTPUT,
+    ISSUE_BYPASS_UNSUPPORTED,
+    SERVICE_BYPASS_ZONE,
+    SERVICE_CLEAR_ALL_BYPASSES,
+    SERVICE_UNBYPASS_ZONE,
     USE_CODE_ARMING,
+    zone_id_from_bypass_unique_id,
 )
 from .entity_id import (
     has_invalid_object_id_chars,
     normalized_mac,
     normalized_object_id,
 )
+from .isapi_bypass import AxProBypassClient
 from .model import (
     Arming,
     ExDevStatusResponse,
@@ -77,6 +92,10 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
 ]
 _LOGGER = logging.getLogger(__name__)
+
+# The zone configuration (names, types, panel-side bypass restrictions)
+# changes rarely; refresh it hourly instead of on every poll.
+ZONE_CONFIG_REFRESH_INTERVAL = timedelta(hours=1)
 
 
 def _migrated_unique_id(
@@ -306,14 +325,18 @@ async def async_setup(hass: HomeAssistant, config: ConfigEntry):
     )
 
     async def _service_bypass_zone(call):
-        zone_id = int(call.data["zone_id"])
-        coordinator = _coordinator_for_service(hass, call)
-        await coordinator.async_bypass_zone(zone_id)
+        manager = _bypass_manager_for_service(hass, call)
+        for zone_id in _zone_ids_from_call(hass, call):
+            await manager.async_bypass_zone(zone_id)
 
-    async def _service_recover_bypass_zone(call):
-        zone_id = int(call.data["zone_id"])
-        coordinator = _coordinator_for_service(hass, call)
-        await coordinator.async_recover_bypass_zone(zone_id)
+    async def _service_unbypass_zone(call):
+        manager = _bypass_manager_for_service(hass, call)
+        for zone_id in _zone_ids_from_call(hass, call):
+            await manager.async_unbypass_zone(zone_id)
+
+    async def _service_clear_all_bypasses(call):
+        manager = _bypass_manager_for_service(hass, call)
+        await manager.async_clear_all(_subsystem_id_from_call(hass, call))
 
     async def _service_arm_away_with_bypass(call):
         coordinator = _coordinator_for_service(hass, call)
@@ -325,9 +348,14 @@ async def async_setup(hass: HomeAssistant, config: ConfigEntry):
         sub_id = call.data.get("sub_id")
         await coordinator.async_arm_home(sub_id=sub_id, with_bypass=True)
 
-    hass.services.async_register(DOMAIN, "bypass_zone", _service_bypass_zone)
+    hass.services.async_register(DOMAIN, SERVICE_BYPASS_ZONE, _service_bypass_zone)
+    hass.services.async_register(DOMAIN, SERVICE_UNBYPASS_ZONE, _service_unbypass_zone)
+    # Backward-compatible alias used by older automations.
     hass.services.async_register(
-        DOMAIN, "recover_bypass_zone", _service_recover_bypass_zone
+        DOMAIN, "recover_bypass_zone", _service_unbypass_zone
+    )
+    hass.services.async_register(
+        DOMAIN, SERVICE_CLEAR_ALL_BYPASSES, _service_clear_all_bypasses
     )
     hass.services.async_register(
         DOMAIN, "arm_away_with_bypass", _service_arm_away_with_bypass
@@ -372,6 +400,58 @@ def _coordinator_for_service(
     return hass.data[DOMAIN][entry_id][DATA_COORDINATOR]
 
 
+def _bypass_manager_for_service(hass: HomeAssistant, call) -> BypassManager:
+    """Resolve the bypass manager backing a service call."""
+    manager = _coordinator_for_service(hass, call).bypass_manager
+    if manager is None:
+        raise HomeAssistantError("Bypass manager not available")
+    return manager
+
+
+def _zone_ids_from_call(hass: HomeAssistant, call) -> list[int]:
+    """Resolve one or more zone IDs from `zone_id` or bypass entity targets."""
+    if call.data.get("zone_id") is not None:
+        return [int(call.data["zone_id"])]
+
+    target = call.data.get("entity_id")
+    if target is None:
+        raise HomeAssistantError("Missing zone_id or target entity_id")
+
+    entity_ids = [target] if isinstance(target, str) else list(target)
+    registry = er.async_get(hass)
+    zone_ids: list[int] = []
+    for entity_id in entity_ids:
+        reg_entry = registry.async_get(entity_id)
+        if reg_entry is None:
+            raise HomeAssistantError(f"Unknown entity_id: {entity_id}")
+        zone_id = zone_id_from_bypass_unique_id(reg_entry.unique_id)
+        if zone_id is None:
+            raise HomeAssistantError(
+                f"Entity {entity_id} is not a zone bypass binary sensor"
+            )
+        zone_ids.append(zone_id)
+    return zone_ids
+
+
+def _subsystem_id_from_call(hass: HomeAssistant, call) -> int | None:
+    """Resolve optional subsystem id from an alarm_control_panel entity target."""
+    target = call.data.get("entity_id")
+    if target is None:
+        return None
+
+    entity_id = target if isinstance(target, str) else (target[0] if target else None)
+    if not entity_id:
+        return None
+
+    registry = er.async_get(hass)
+    reg_entry = registry.async_get(entity_id)
+    if reg_entry is None or not reg_entry.unique_id:
+        return None
+
+    match = re.fullmatch(r"subsys-.*-(\d+)", reg_entry.unique_id)
+    return int(match.group(1)) if match else None
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up hikvision_axpro from a config entry."""
     host = entry.data[CONF_HOST]
@@ -382,7 +462,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     code = entry.data[CONF_CODE]
     use_code_arming = entry.data[USE_CODE_ARMING]
     use_sub_systems = entry.data.get(ALLOW_SUBSYSTEMS, False)
-    auto_bypass_on_arm = entry.data.get(AUTO_BYPASS_ON_ARM, False)
     axpro = hikaxpro.HikAxPro(
         host, username, password, user_level=hikaxpro.USER_LEVEL_ADMIN_OPERATOR
     )
@@ -410,15 +489,53 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         code,
         update_interval,
         use_sub_systems,
-        auto_bypass_on_arm=auto_bypass_on_arm,
     )
     try:
         async with timeout(10):
             await hass.async_add_executor_job(coordinator.init_device)
     except (TimeoutError, ConnectionError) as ex:
         raise ConfigEntryNotReady from ex
+    bypass_store = BypassStore(hass, entry.entry_id)
+    await bypass_store.async_load()
+
+    bypass_manager = BypassManager(
+        hass, entry, coordinator, AxProBypassClient(axpro), bypass_store
+    )
+    # A firmware that reports the per-zone bypass state supports the
+    # bypass control endpoint; detected from already-fetched data.
+    bypass_supported = any(
+        zone.bypassed is not None for zone in (coordinator.zones or {}).values()
+    )
+    bypass_manager.bypass_supported = bypass_supported
+    coordinator.bypass_manager = bypass_manager
+    bypass_manager.async_report_ineffective_config()
+    if not bypass_supported:
+        _LOGGER.warning(
+            "Panel %s does not report zone bypass states; "
+            "bypass features are disabled",
+            coordinator.device_name,
+        )
+        ir.async_create_issue(
+            hass,
+            DOMAIN,
+            f"{ISSUE_BYPASS_UNSUPPORTED}_{entry.entry_id}",
+            is_fixable=False,
+            severity=ir.IssueSeverity.WARNING,
+            translation_key=ISSUE_BYPASS_UNSUPPORTED,
+            translation_placeholders={"device": coordinator.device_name or ""},
+        )
+    else:
+        ir.async_delete_issue(
+            hass, DOMAIN, f"{ISSUE_BYPASS_UNSUPPORTED}_{entry.entry_id}"
+        )
+
     hass.data.setdefault(DOMAIN, {})
-    hass.data[DOMAIN][entry.entry_id] = {DATA_COORDINATOR: coordinator}
+    hass.data[DOMAIN][entry.entry_id] = {
+        DATA_COORDINATOR: coordinator,
+        DATA_BYPASS_MANAGER: bypass_manager,
+    }
+
+    entry.async_on_unload(entry.add_update_listener(update_listener))
 
     await _async_migrate_unique_ids(hass, entry, coordinator.device_name, mac)
     await _async_migrate_invalid_entity_ids(hass, entry)
@@ -436,7 +553,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
-        hass.data[DOMAIN].pop(entry.entry_id)
+        data = hass.data[DOMAIN].pop(entry.entry_id)
+        manager: BypassManager | None = data.get(DATA_BYPASS_MANAGER)
+        if manager is not None:
+            manager.async_unload()
 
     return unload_ok
 
@@ -472,7 +592,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
     one_key_alarm_supported: bool | None = None
     siren_ctrl_supported: bool | None = None
     use_sub_systems: bool
-    auto_bypass_on_arm: bool
+    bypass_manager: "BypassManager | None" = None
 
     def __init__(
         self,
@@ -485,7 +605,6 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         code,
         update_interval: float,
         use_sub_systems=False,
-        auto_bypass_on_arm=False,
     ) -> None:
         """Initialize global data updater and AXPro API."""
         self.axpro = axpro
@@ -501,7 +620,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
         self.use_code_arming = use_code_arming
         self.code = code
         self.use_sub_systems = use_sub_systems
-        self.auto_bypass_on_arm = auto_bypass_on_arm
+        self._last_zone_config_fetch: datetime | None = None
         self.sirens = {}
         self.keypads = {}
         self.repeaters = {}
@@ -647,6 +766,7 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
     def load_devices(self):
         """Load devices from Zone Config."""
         devices = self._load_devices()
+        self._last_zone_config_fetch = dt_util.utcnow()
         if devices is not None:
             self.devices = {}
             for item in devices.list:
@@ -730,6 +850,23 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
             zones[zone.zone.id] = zone.zone
         self.zones = zones
         _LOGGER.debug("Zones: %s", zone_response)
+        # Refresh the zone configuration hourly, so panel-side setting
+        # changes (e.g. "forbid bypass on arming") are picked up without
+        # a reload while keeping the poll cycle light. A failed refresh
+        # keeps the previous configuration and is retried next poll.
+        if (
+            self._last_zone_config_fetch is None
+            or dt_util.utcnow() - self._last_zone_config_fetch
+            >= ZONE_CONFIG_REFRESH_INTERVAL
+        ):
+            try:
+                self.load_devices()
+            except Exception as err:  # noqa: BLE001 - keep polling alive
+                _LOGGER.warning(
+                    "Zone configuration refresh failed; keeping the previous "
+                    "one: %s",
+                    err,
+                )
         # peripherals from exDevStatus
         devices_status = self._load_ext_devices_status()
         relays_status: dict[int, OutputStatusFull] = {}
@@ -823,74 +960,86 @@ class HikAxProDataUpdateCoordinator(DataUpdateCoordinator):
                 await self.hass.async_add_executor_job(self._update_data)
         except ConnectionError as error:
             raise UpdateFailed(error) from error
+        if self.bypass_manager is not None:
+            await self.bypass_manager.async_on_data_refreshed()
+
+    async def _async_arm(
+        self, arm_command, sub_id: int | None, mode: str, with_bypass: bool = False
+    ) -> None:
+        """Run the pre-arm bypass flow, then send the arm command."""
+        manager = self.bypass_manager
+        if manager is None:
+            is_success = await self.hass.async_add_executor_job(arm_command, sub_id)
+        else:
+            if manager.arm_lock.locked():
+                raise HomeAssistantError(
+                    "Another arming or bypass operation is already in progress",
+                    translation_domain=DOMAIN,
+                    translation_key="arming_in_progress",
+                )
+            async with manager.arm_lock:
+                await manager.async_prepare_arming(sub_id, mode, with_bypass)
+                is_success = await self.hass.async_add_executor_job(
+                    arm_command, sub_id
+                )
+
+        if not is_success:
+            raise HomeAssistantError(
+                "The panel refused the arm command",
+                translation_domain=DOMAIN,
+                translation_key="arm_refused",
+            )
+        await self._async_update_data()
+        await self.async_request_refresh()
+
+    def _arm_vacation(self, sub_id: int | None):
+        """Send the vacation arm command (not exposed by hikaxpro)."""
+        sid = "0xffffffff" if sub_id is None else str(sub_id)
+        endpoint = self.axpro.build_url(
+            f"http://{self.host}/ISAPI/SecurityCP/control/arm/{sid}?ways=vacation",
+            True,
+        )
+        response = self.axpro.make_request(endpoint, "PUT", None, True)
+        if response.status_code != 200:
+            raise hikaxpro.errors.UnexpectedResponseCodeError(
+                response.status_code, response.text
+            )
+        return bool(response.json())
 
     async def async_arm_home(self, sub_id: int | None = None, with_bypass: bool = False):
-        """Arm alarm panel in home state."""
-        if with_bypass or self.auto_bypass_on_arm:
-            await self.async_bypass_blocking_zones()
-        is_success = await self.hass.async_add_executor_job(self.axpro.arm_home, sub_id)
+        """Arm alarm panel in home state.
 
-        if is_success:
-            await self._async_update_data()
-            await self.async_request_refresh()
+        ``with_bypass`` runs the pre-arm bypass flow even when home
+        arming is not in the auto-bypass modes.
+        """
+        await self._async_arm(self.axpro.arm_home, sub_id, ARM_MODE_HOME, with_bypass)
 
     async def async_arm_away(self, sub_id: int | None = None, with_bypass: bool = False):
-        """Arm alarm panel in away state."""
-        if with_bypass or self.auto_bypass_on_arm:
-            await self.async_bypass_blocking_zones()
-        is_success = await self.hass.async_add_executor_job(self.axpro.arm_away, sub_id)
+        """Arm alarm panel in away state.
 
-        if is_success:
-            await self._async_update_data()
-            await self.async_request_refresh()
+        ``with_bypass`` runs the pre-arm bypass flow even when away
+        arming is not in the auto-bypass modes.
+        """
+        await self._async_arm(self.axpro.arm_away, sub_id, ARM_MODE_AWAY, with_bypass)
+
+    async def async_arm_vacation(self, sub_id: int | None = None):
+        """Arm alarm panel in vacation state."""
+        await self._async_arm(self._arm_vacation, sub_id, ARM_MODE_VACATION)
 
     async def async_disarm(self, sub_id: int | None = None):
         """Disarm alarm control panel."""
         is_success = await self.hass.async_add_executor_job(self.axpro.disarm, sub_id)
 
-        if is_success:
-            await self._async_update_data()
-            await self.async_request_refresh()
-
-    def _zones_blocking_arm(self) -> list[int]:
-        """Return zone IDs that typically prevent arming when left open/triggered."""
-        if not self.zones:
-            return []
-        blocking: list[int] = []
-        for zone_id, zone in self.zones.items():
-            if zone.bypassed:
-                continue
-            open_magnet = zone.magnet_open_status is True
-            triggered = zone.status is Status.TRIGGER
-            alarming = zone.alarm is True
-            if open_magnet or triggered or alarming:
-                blocking.append(zone_id)
-        return blocking
-
-    async def async_bypass_blocking_zones(self) -> None:
-        """Bypass zones that look open/triggered before arming."""
-        for zone_id in self._zones_blocking_arm():
-            await self.async_bypass_zone(zone_id)
-
-    async def async_bypass_zone(self, zone_id: int) -> bool:
-        """Bypass a single zone."""
-        is_success = await self.hass.async_add_executor_job(
-            self.axpro.bypass_zone, zone_id
-        )
-        if is_success:
-            await self._async_update_data()
-            await self.async_request_refresh()
-        return is_success
-
-    async def async_recover_bypass_zone(self, zone_id: int) -> bool:
-        """Clear bypass on a single zone."""
-        is_success = await self.hass.async_add_executor_job(
-            self.axpro.recover_bypass_zone, zone_id
-        )
-        if is_success:
-            await self._async_update_data()
-            await self.async_request_refresh()
-        return is_success
+        if not is_success:
+            raise HomeAssistantError(
+                "The panel refused the disarm command",
+                translation_domain=DOMAIN,
+                translation_key="disarm_refused",
+            )
+        if self.bypass_manager is not None:
+            await self.bypass_manager.async_on_disarm(sub_id)
+        await self._async_update_data()
+        await self.async_request_refresh()
 
     def _relay_call(self, relay_id: int, is_enabled: bool) -> JSONResponseStatus:
         endpoint = self.axpro.build_url(

--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -13,14 +13,19 @@ from homeassistant.components.alarm_control_panel import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.components.alarm_control_panel import DOMAIN as PANEL_DOMAIN
-from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers import device_registry as dr, entity_platform
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import Arming, HikAxProDataUpdateCoordinator, SubSys
-from .const import ALLOW_SUBSYSTEMS, DATA_COORDINATOR, DOMAIN
 from .entity_id import build_entity_id
+from .const import (
+    ALLOW_SUBSYSTEMS,
+    DATA_COORDINATOR,
+    DOMAIN,
+    SERVICE_CLEAR_ALL_BYPASSES,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +37,12 @@ async def async_setup_entry(
     coordinator: HikAxProDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id][
         DATA_COORDINATOR
     ]
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        SERVICE_CLEAR_ALL_BYPASSES,
+        None,
+        "async_clear_all_bypasses",
+    )
     device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         config_entry_id=entry.entry_id,
@@ -73,6 +84,7 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.ARM_VACATION
     )
 
     @property
@@ -143,6 +155,26 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
 
         await self.coordinator.async_arm_away()
 
+    async def async_alarm_arm_vacation(self, code=None):
+        """Send arm vacation command."""
+        if self.coordinator.use_code and self.coordinator.use_code_arming:
+            if not self.__is_code_valid(code):
+                return
+
+        await self.coordinator.async_arm_vacation()
+
+    async def async_clear_all_bypasses(self):
+        """Remove all bypasses on the panel (service handler)."""
+        if self.coordinator.bypass_manager is not None:
+            await self.coordinator.bypass_manager.async_clear_all()
+
+    @property
+    def extra_state_attributes(self):
+        """Return bypass diagnostic attributes."""
+        if self.coordinator.bypass_manager is None:
+            return None
+        return self.coordinator.bypass_manager.diagnostics()
+
     def __is_code_valid(self, code):
         return code == self.coordinator.code
 
@@ -176,6 +208,7 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
     _attr_supported_features = (
         AlarmControlPanelEntityFeature.ARM_HOME
         | AlarmControlPanelEntityFeature.ARM_AWAY
+        | AlarmControlPanelEntityFeature.ARM_VACATION
     )
 
     @property
@@ -255,6 +288,26 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
                 return
 
         await self.coordinator.async_arm_away(self.sys.id)
+
+    async def async_alarm_arm_vacation(self, code=None):
+        """Send arm vacation command."""
+        if self.coordinator.use_code and self.coordinator.use_code_arming:
+            if not self.__is_code_valid(code):
+                return
+
+        await self.coordinator.async_arm_vacation(self.sys.id)
+
+    async def async_clear_all_bypasses(self):
+        """Remove all bypasses in this area (service handler)."""
+        if self.coordinator.bypass_manager is not None:
+            await self.coordinator.bypass_manager.async_clear_all(self.sys.id)
+
+    @property
+    def extra_state_attributes(self):
+        """Return bypass diagnostic attributes for this area."""
+        if self.coordinator.bypass_manager is None:
+            return None
+        return self.coordinator.bypass_manager.diagnostics(self.sys.id)
 
     def __is_code_valid(self, code):
         return code == self.coordinator.code

--- a/custom_components/hikvision_axpro/alarm_control_panel.py
+++ b/custom_components/hikvision_axpro/alarm_control_panel.py
@@ -12,6 +12,7 @@ from homeassistant.components.alarm_control_panel import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.components.alarm_control_panel import DOMAIN as PANEL_DOMAIN
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -19,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import Arming, HikAxProDataUpdateCoordinator, SubSys
 from .const import ALLOW_SUBSYSTEMS, DATA_COORDINATOR, DOMAIN
+from .entity_id import build_entity_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -55,6 +57,14 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
 
     _attr_code_arm_required = False
 
+    def __init__(self, coordinator: HikAxProDataUpdateCoordinator) -> None:
+        """Initialize the panel and pin its entity id."""
+        super().__init__(coordinator=coordinator)
+        self.entity_id = build_entity_id(
+            PANEL_DOMAIN, coordinator.mac_id, coordinator.mac_id,
+            coordinator.device_name,
+        )
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
@@ -69,7 +79,7 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     def device_info(self) -> DeviceInfo:
         """Return device info for this device."""
         return DeviceInfo(
-            identifiers={(DOMAIN, self.unique_id)},
+            identifiers={(DOMAIN, self.coordinator.mac)},
             manufacturer="Hikvision - Ax Pro",
             model=self.coordinator.device_model,
             name=self.coordinator.device_name,
@@ -78,7 +88,7 @@ class HikAxProPanel(CoordinatorEntity, AlarmControlPanelEntity):
     @property
     def unique_id(self):
         """Return a unique id."""
-        return self.coordinator.mac
+        return self.coordinator.mac_id
 
     @property
     def name(self):
@@ -149,6 +159,9 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
         """Initialize subpanel."""
         self.sys = sys
         super().__init__(coordinator=coordinator)
+        self.entity_id = build_entity_id(
+            PANEL_DOMAIN, self.unique_id, coordinator.mac_id, sys.name
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -178,7 +191,7 @@ class HikAxProSubPanel(CoordinatorEntity, AlarmControlPanelEntity):
     @property
     def unique_id(self):
         """Return a unique id."""
-        return "subsys-" + self.coordinator.mac + str(self.sys.id)
+        return f"subsys-{self.coordinator.mac_id}-{self.sys.id}"
 
     @property
     def name(self):

--- a/custom_components/hikvision_axpro/binary_sensor.py
+++ b/custom_components/hikvision_axpro/binary_sensor.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 import logging
 
 from homeassistant.components.binary_sensor import (
-    DOMAIN as SENSOR_DOMAIN,
+    DOMAIN as BINARY_SENSOR_DOMAIN,
     BinarySensorDeviceClass,
     BinarySensorEntity,
 )
@@ -21,8 +21,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HikAxProDataUpdateCoordinator
 from .const import DATA_COORDINATOR, DOMAIN
-from .hik_device import HikDevice
 from .entity_id import build_entity_id
+from .hik_device import HikDevice
 from .model import (
     MOTION_DETECTOR_TYPES,
     DetectorType,
@@ -192,13 +192,13 @@ class HikWirelessExtMagnetDetector(CoordinatorEntity, HikDevice, BinarySensorEnt
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:magnet"
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -251,12 +251,12 @@ class HikMagneticContactDetector(CoordinatorEntity, HikDevice, BinarySensorEntit
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -309,12 +309,12 @@ class HikMagnetShockDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-shock-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-shock-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-shock", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -376,12 +376,12 @@ class HikMagnetOpenDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-open-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-open-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-open", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -443,12 +443,12 @@ class HikMagnetTiltDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-magnet-tilt-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-magnet-tilt-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "magnet-tilt", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -510,12 +510,12 @@ class HikMotionDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-motion-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-motion-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_device_class = BinarySensorDeviceClass.MOTION
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "motion", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -563,14 +563,14 @@ class HikTamperDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-tamper-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-tamper-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:electric-switch"
         self._attr_device_class = BinarySensorDeviceClass.TAMPER
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "tamper", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -609,14 +609,14 @@ class HikBypassDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-bypass-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-bypass-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:alarm-light-off"
         self._attr_device_class = BinarySensorDeviceClass.SAFETY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "bypass", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -655,14 +655,14 @@ class HikArmedInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-armed-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-armed-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:lock"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "armed", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -701,14 +701,14 @@ class HikAlarmInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-alarm-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-alarm-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:alarm-light"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "alarm", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -747,14 +747,14 @@ class HikStayAwayInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-stayaway-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-stayaway-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:shield-lock-outline"
         self._attr_device_class = BinarySensorDeviceClass.LOCK
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "stayaway", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -793,14 +793,14 @@ class HikIsViaRepeaterInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-isviarepeater-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-isviarepeater-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:google-circles-extended"
         self._attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "isviarepeater", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -839,14 +839,14 @@ class HikBinaryBatteryInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-battery-low-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-battery-low-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery"
         self._attr_device_class = BinarySensorDeviceClass.BATTERY
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "battery-low", zone.id
-        )
 
     @property
     def name(self) -> str | None:

--- a/custom_components/hikvision_axpro/binary_sensor.py
+++ b/custom_components/hikvision_axpro/binary_sensor.py
@@ -14,13 +14,21 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers import device_registry as dr
-from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers import device_registry as dr, entity_registry as er
+from homeassistant.helpers.entity import DeviceInfo, EntityCategory
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HikAxProDataUpdateCoordinator
-from .const import DATA_COORDINATOR, DOMAIN
+from .bypass_manager import is_auto_bypass_eligible
+from .const import (
+    ARM_MODES,
+    DATA_COORDINATOR,
+    DOMAIN,
+    SERVICE_BYPASS_ZONE,
+    SERVICE_UNBYPASS_ZONE,
+)
 from .entity_id import build_entity_id
 from .hik_device import HikDevice
 from .model import (
@@ -176,8 +184,77 @@ async def async_setup_entry(
                 devices.append(
                     HikBinaryBatteryInfo(coordinator, zone.zone, entry.entry_id)
                 )
+            devices.extend(
+                _zone_bypassable_sensors(coordinator, zone.zone, entry.entry_id)
+            )
+
+    devices.extend(
+        HikReadyToArmSensor(coordinator, entry.entry_id, mode) for mode in ARM_MODES
+    )
+    _remove_stale_bypass_entities(hass, coordinator)
+
     _LOGGER.debug("setting up - sensors: %s", ",".join(x.name for x in devices))
     async_add_entities(devices, False)
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(SERVICE_BYPASS_ZONE, None, "async_bypass")
+    platform.async_register_entity_service(
+        SERVICE_UNBYPASS_ZONE, None, "async_unbypass"
+    )
+
+
+def _zone_bypassable_sensors(
+    coordinator: HikAxProDataUpdateCoordinator, zone: Zone, entry_id: str
+) -> list[BinarySensorEntity]:
+    """Per-mode bypassable readback for a zone that may be auto-bypassed.
+
+    Only instant zones get them: the panel offers "forbid bypass on
+    arming" exclusively for that type, so no other type is ever bypassed
+    automatically and a sensor stuck at off would only be noise.
+    """
+    if not is_auto_bypass_eligible(zone):
+        return []
+    manager = coordinator.bypass_manager
+    modes = manager.auto_bypass_modes if manager is not None else set(ARM_MODES)
+    return [
+        HikZoneBypassableSensor(coordinator, zone, entry_id, mode)
+        for mode in ARM_MODES
+        if mode in modes
+    ]
+
+
+def _remove_stale_bypass_entities(
+    hass: HomeAssistant, coordinator: HikAxProDataUpdateCoordinator
+) -> None:
+    """Drop bypass entities that no longer apply.
+
+    Covers a zone whose type changed on the panel, a mode whose
+    auto-bypass was switched off, and the switches earlier builds used
+    before the configuration moved into the integration options.
+    """
+    registry = er.async_get(hass)
+    manager = coordinator.bypass_manager
+    modes = manager.auto_bypass_modes if manager is not None else set(ARM_MODES)
+
+    def remove(domain: str, unique_id: str) -> None:
+        if stale_id := registry.async_get_entity_id(domain, DOMAIN, unique_id):
+            _LOGGER.debug("Removing stale entity %s", stale_id)
+            registry.async_remove(stale_id)
+
+    for zone_id in list((coordinator.zones or {})):
+        zone = coordinator.zones[zone_id]
+        for mode in ARM_MODES:
+            unique_id = f"{coordinator.mac_id}-bypassable-{mode}-{zone_id}"
+            # The configuration now lives in the config entry, so the
+            # per-zone switch is gone whatever the mode.
+            remove("switch", unique_id)
+            if is_auto_bypass_eligible(zone) and mode in modes:
+                continue
+            remove("binary_sensor", unique_id)
+        remove("switch", f"{coordinator.mac_id}-bypassable-{zone_id}")
+
+    # Mode-less ready-to-arm sensor used by earlier builds.
+    remove("binary_sensor", f"{coordinator.mac_id}-ready-to-arm")
 
 
 class HikWirelessExtMagnetDetector(CoordinatorEntity, HikDevice, BinarySensorEntity):
@@ -641,6 +718,172 @@ class HikBypassDetection(CoordinatorEntity, HikDevice, BinarySensorEntity):
             return self.coordinator.zones[self.zone.id].bypassed
         else:
             return False
+
+    @property
+    def extra_state_attributes(self):
+        """Expose owner and reason of the current bypass."""
+        manager = self.coordinator.bypass_manager
+        if manager is None or not self.is_on:
+            return None
+        owned = manager.owns_zone(self.zone.id)
+        return {
+            "bypass_owner": "integration" if owned else "external",
+            "bypass_reason": manager.bypass_reason(self.zone.id),
+        }
+
+    async def async_bypass(self):
+        """Bypass this zone (service handler)."""
+        if self.coordinator.bypass_manager is not None:
+            await self.coordinator.bypass_manager.async_bypass_zone(self.zone.id)
+
+    async def async_unbypass(self):
+        """Restore this zone (service handler)."""
+        if self.coordinator.bypass_manager is not None:
+            await self.coordinator.bypass_manager.async_unbypass_zone(self.zone.id)
+
+
+class HikZoneBypassableSensor(CoordinatorEntity, HikDevice, BinarySensorEntity):
+    """Whether this zone is set as bypassable for one arming mode.
+
+    Read-only: which zones may be auto-bypassed is chosen once in the
+    integration options, not per zone. The sensor is off when the panel
+    itself forbids bypassing the zone on arming
+    (``armNoBypassEnabled``) or when its type is not eligible, because
+    the panel-side setting always wins over the HA-side configuration.
+    """
+
+    coordinator: HikAxProDataUpdateCoordinator
+
+    def __init__(
+        self,
+        coordinator: HikAxProDataUpdateCoordinator,
+        zone: Zone,
+        entry_id: str,
+        mode: str,
+    ) -> None:
+        """Create the entity with a DataUpdateCoordinator."""
+        super().__init__(coordinator)
+        self.zone = zone
+        self._ref_id = entry_id
+        self._mode = mode
+        self._attr_unique_id = f"{coordinator.mac_id}-bypassable-{mode}-{zone.id}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
+        self._attr_icon = "mdi:shield-off-outline"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+        self._attr_has_entity_name = True
+
+    @property
+    def name(self) -> str | None:
+        return f"Bypassable on {self._mode} arming"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true if the zone may be auto-bypassed in this mode."""
+        manager = self.coordinator.bypass_manager
+        if manager is None:
+            return None
+        return manager.is_bypassable(self.zone.id, self._mode)
+
+    @property
+    def available(self) -> bool:
+        manager = self.coordinator.bypass_manager
+        return manager is not None and manager.bypass_supported
+
+    @property
+    def extra_state_attributes(self):
+        """Explain why a configured zone is not effective, if it is not."""
+        manager = self.coordinator.bypass_manager
+        if manager is None:
+            return None
+        attrs = {"arming_mode": self._mode}
+        configured = manager.is_configured_bypassable(self.zone.id, self._mode)
+        attrs["configured"] = configured
+        if configured and manager.zone_forbids_bypass(self.zone.id):
+            attrs["forbidden_by_panel_config"] = True
+        if configured and not manager.zone_bypass_allowed(self.zone.id):
+            attrs["ineffective_reason"] = (
+                "forbidden_by_panel_config"
+                if manager.zone_forbids_bypass(self.zone.id)
+                else "zone_type_not_eligible"
+            )
+        if manager.owns_zone(self.zone.id):
+            attrs["bypass_owner"] = "integration"
+            attrs["bypass_reason"] = manager.bypass_reason(self.zone.id)
+        return attrs
+
+
+class HikReadyToArmSensor(CoordinatorEntity, BinarySensorEntity):
+    """Whether arming in one mode would currently succeed.
+
+    On when no zone is in fault or every faulted zone is set bypassable;
+    off when at least one faulted zone would block arming. One sensor
+    exists per arming mode, independent of the auto-bypass
+    configuration. Advisory: computed from polled data with the same
+    evaluation used at arm time; the authoritative check runs
+    synchronously when arming.
+    """
+
+    coordinator: HikAxProDataUpdateCoordinator
+
+    def __init__(
+        self, coordinator: HikAxProDataUpdateCoordinator, entry_id: str, mode: str
+    ) -> None:
+        """Create the entity with a DataUpdateCoordinator."""
+        super().__init__(coordinator)
+        self._entry_id = entry_id
+        self._mode = mode
+        self._attr_unique_id = f"{coordinator.mac_id}-ready-to-arm-{mode}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
+        self._attr_icon = "mdi:shield-check"
+        self._attr_has_entity_name = True
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Handle updated data from the coordinator."""
+        self.async_write_ha_state()
+
+    @property
+    def name(self) -> str | None:
+        return f"Ready to arm {self._mode}"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the panel device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self.coordinator.mac)},
+            manufacturer="Hikvision - Ax Pro",
+            model=self.coordinator.device_model,
+            name=self.coordinator.device_name,
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return true when arming would succeed under the logic."""
+        manager = self.coordinator.bypass_manager
+        if manager is None or self.coordinator.zones is None:
+            return None
+        return manager.current_readiness(self._mode).ready
+
+    @property
+    def extra_state_attributes(self):
+        """Expose the evaluation details."""
+        manager = self.coordinator.bypass_manager
+        if manager is None:
+            return None
+        result = manager.current_readiness(self._mode)
+        return {
+            "blocking_zones": result.blocking_zones,
+            "zones_to_bypass": result.zones_to_bypass,
+            "areas": {
+                str(area): breakdown for area, breakdown in result.per_area.items()
+            },
+            "evaluated_mode": self._mode,
+            "advisory": True,
+        }
 
 
 class HikArmedInfo(CoordinatorEntity, HikDevice, BinarySensorEntity):

--- a/custom_components/hikvision_axpro/button.py
+++ b/custom_components/hikvision_axpro/button.py
@@ -49,9 +49,9 @@ class HikOneKeyAlarmButton(CoordinatorEntity, ButtonEntity):
         self._attr_has_entity_name = True
         self._attr_name = "One-key alarm"
         self._attr_icon = "mdi:alarm-light"
-        self._attr_unique_id = f"{coordinator.device_name}-one-key-alarm"
+        self._attr_unique_id = f"{coordinator.mac_id}-one-key-alarm"
         self.entity_id = build_entity_id(
-            BUTTON_DOMAIN, coordinator.device_name, "one_key_alarm"
+            BUTTON_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.mac))},
@@ -83,9 +83,9 @@ class HikOneKeyAlarmClearButton(CoordinatorEntity, ButtonEntity):
         self._attr_has_entity_name = True
         self._attr_name = "Clear one-key alarm"
         self._attr_icon = "mdi:alarm-light-off"
-        self._attr_unique_id = f"{coordinator.device_name}-one-key-alarm-clear"
+        self._attr_unique_id = f"{coordinator.mac_id}-one-key-alarm-clear"
         self.entity_id = build_entity_id(
-            BUTTON_DOMAIN, coordinator.device_name, "one_key_alarm_clear"
+            BUTTON_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(coordinator.mac))},

--- a/custom_components/hikvision_axpro/bypass_manager.py
+++ b/custom_components/hikvision_axpro/bypass_manager.py
@@ -1,0 +1,880 @@
+"""Zone bypass policy for the hikvision_axpro integration.
+
+Implements the auto-bypass-on-arming flow (per arming mode), ownership
+tracking of integration-applied bypasses, automatic re-enable on
+recovery, cleanup on disarm and reconciliation with panel state. The
+ISAPI primitives live in ``isapi_bypass.py``; this module is pure
+policy.
+"""
+
+from __future__ import annotations
+
+from asyncio import Lock, timeout
+from dataclasses import dataclass, field
+from datetime import datetime
+import logging
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import CALLBACK_TYPE, HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.event import async_call_later
+from homeassistant.util import dt as dt_util
+
+from .const import (
+    ARM_MODE_AWAY,
+    ARM_MODE_HOME,
+    ARM_MODES,
+    CONF_AUTO_BYPASS_MODES,
+    CONF_BYPASS_REENABLE_DEBOUNCE,
+    CONF_CLEAR_ALL_ON_DISARM,
+    DEFAULT_BYPASS_REENABLE_DEBOUNCE,
+    DOMAIN,
+    EVENT_ARMING_BLOCKED,
+    EVENT_BYPASS_APPLIED,
+    EVENT_BYPASS_REMOVED,
+    conf_bypassable_zones,
+)
+from .bypass_store import BypassStore, OwnedBypass
+from .isapi_bypass import AxProBypassClient, BypassError
+from .model import Arming, Status, Zone, ZoneType, ZonesResponse
+
+if TYPE_CHECKING:
+    from . import HikAxProDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+# Zone types eligible for auto-bypass. Only instant zones: the panel
+# itself offers the "forbid bypass on arming" option exclusively for
+# them, so every other type (delay, perimeter, follow, 24h, fire, gas,
+# medical, emergency, key, non-alarm) is never bypassed automatically.
+AUTO_BYPASS_ALLOWED_ZONE_TYPES = frozenset({ZoneType.INSTANT})
+
+# Reconciliation grace period: an owned bypass applied more recently than
+# this may legitimately not appear in the current poll snapshot yet.
+RECONCILE_GRACE_SECONDS = 15
+
+FRESH_READ_TIMEOUT = 10
+
+FAULT_OPEN = "open"
+FAULT_OFFLINE = "offline"
+FAULT_TAMPER = "tamper"
+
+REASON_AUTO_ARM = "auto_arm"
+REASON_SERVICE = "service"
+REASON_HEALTH_RECOVERED = "health_recovered"
+REASON_DISARM = "disarm"
+REASON_ROLLBACK = "rollback"
+REASON_RECONCILED = "reconciled"
+
+
+class ArmingBlockedError(HomeAssistantError):
+    """Arming was aborted by the pre-arm bypass logic."""
+
+    def __init__(self, message: str, zones: str = "") -> None:
+        """Store a translated, zone-listing error."""
+        full_message = f"{message}: {zones}" if zones else message
+        super().__init__(
+            full_message,
+            translation_domain=DOMAIN,
+            translation_key="arming_blocked",
+            translation_placeholders={"reason": message, "zones": zones},
+        )
+
+
+def zone_fault_reason(zone: Zone) -> str | None:
+    """Return why a zone is in fault, or None if healthy.
+
+    A zone is faulted when triggered/open, offline or tampered. Low
+    battery is deliberately a warning only: it neither blocks arming nor
+    causes a bypass.
+    """
+    if zone.status == Status.NOT_RELATED:
+        return None
+    if zone.tamper_evident:
+        return FAULT_TAMPER
+    if zone.status in (Status.OFFLINE, Status.BREAK_DOWN, Status.HEART_BEAT_ABNORMAL):
+        return FAULT_OFFLINE
+    if zone.alarm or zone.status == Status.TRIGGER or zone.magnet_open_status:
+        return FAULT_OPEN
+    if zone.charge == "lowPower":
+        _LOGGER.warning(
+            "Zone %s (%s) reports low battery; not blocking arming", zone.id, zone.name
+        )
+    return None
+
+
+def is_auto_bypass_eligible(zone: Zone) -> bool:
+    """Return True if the zone type may be auto-bypassed."""
+    return zone.zone_type in AUTO_BYPASS_ALLOWED_ZONE_TYPES
+
+
+def zone_in_area(zone: Zone, sub_id: int | None) -> bool:
+    """Return True if the zone belongs to the given area."""
+    if sub_id is None:
+        return True
+    if zone.sub_system_no is not None:
+        return zone.sub_system_no == sub_id
+    return bool(zone.linkage_sub_system and sub_id in zone.linkage_sub_system)
+
+
+def _zone_issue(zone: Zone, fault: str) -> dict[str, Any]:
+    return {
+        "zone_id": zone.id,
+        "zone_name": zone.name,
+        "area": zone.sub_system_no,
+        "fault": fault,
+    }
+
+
+@dataclass
+class ReadinessResult:
+    """Outcome of the arm readiness evaluation."""
+
+    blocking_zones: list[dict[str, Any]] = field(default_factory=list)
+    zones_to_bypass: list[dict[str, Any]] = field(default_factory=list)
+
+    @property
+    def ready(self) -> bool:
+        """True when no non-bypassable zone is in fault."""
+        return not self.blocking_zones
+
+    @property
+    def per_area(self) -> dict[int, dict[str, Any]]:
+        """Per-area breakdown for multi-partition systems."""
+        areas: dict[int, dict[str, Any]] = {}
+
+        def bucket(area: int | None) -> dict[str, Any]:
+            key = area if area is not None else 0
+            return areas.setdefault(
+                key, {"ready": True, "blocking_zones": [], "zones_to_bypass": []}
+            )
+
+        for issue in self.blocking_zones:
+            entry = bucket(issue["area"])
+            entry["blocking_zones"].append(issue)
+            entry["ready"] = False
+        for issue in self.zones_to_bypass:
+            bucket(issue["area"])["zones_to_bypass"].append(issue)
+        return areas
+
+
+def evaluate_arm_readiness(
+    zones: list[Zone], bypassable_ids: set[int], mode: str = ARM_MODE_AWAY
+) -> ReadinessResult:
+    """Evaluate whether arming in ``mode`` would succeed.
+
+    Single source of truth. Faulted zones split into
+    ``zones_to_bypass`` (marked bypassable and of an eligible type) and
+    ``blocking_zones`` (everything else). Already-bypassed zones are
+    skipped and never touched. In home (stay) mode, zones the panel
+    itself bypasses on stay arming (``stayAway``) are ignored.
+    """
+    result = ReadinessResult()
+    for zone in zones:
+        if zone.bypassed:
+            continue
+        if mode == ARM_MODE_HOME and zone.stay_away:
+            continue
+        fault = zone_fault_reason(zone)
+        if fault is None:
+            continue
+        if zone.id in bypassable_ids and is_auto_bypass_eligible(zone):
+            result.zones_to_bypass.append(_zone_issue(zone, fault))
+        else:
+            result.blocking_zones.append(_zone_issue(zone, fault))
+    return result
+
+
+class BypassManager:
+    """Coordinates bypass policy for one panel (config entry)."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        entry: ConfigEntry,
+        coordinator: HikAxProDataUpdateCoordinator,
+        client: AxProBypassClient,
+        store: BypassStore,
+    ) -> None:
+        """Initialize the manager."""
+        self.hass = hass
+        self.entry = entry
+        self.coordinator = coordinator
+        self.client = client
+        self.store = store
+        self.bypass_supported = True
+        self.arm_lock = Lock()
+        self._healthy_since: dict[int, datetime] = {}
+        self._reenable_unsub: dict[int, CALLBACK_TYPE] = {}
+        self._last_arming: dict[int, Arming | None] = {}
+        self._reported_ineffective: dict[str, set[int]] = {}
+
+    # ------------------------------------------------------------------
+    # Configuration views
+
+    @property
+    def auto_bypass_modes(self) -> set[str]:
+        """Arming modes for which the auto-bypass logic is enabled."""
+        modes = self.entry.data.get(CONF_AUTO_BYPASS_MODES) or []
+        return {mode for mode in modes if mode in ARM_MODES}
+
+    def _configured_bypassable(self, mode: str) -> set[int]:
+        """Zone ids the user picked for one mode, ungated.
+
+        The configuration lives in the config entry: it is chosen once in
+        the integration options rather than per zone, so it survives a
+        zone going offline and never depends on entity state.
+        """
+        if mode not in ARM_MODES:
+            mode = ARM_MODE_AWAY
+        configured = self.entry.data.get(conf_bypassable_zones(mode)) or []
+        ids: set[int] = set()
+        for zone_id in configured:
+            try:
+                ids.add(int(zone_id))
+            except (TypeError, ValueError):
+                _LOGGER.warning(
+                    "Ignoring unusable bypassable zone %r configured for %s arming",
+                    zone_id,
+                    mode,
+                )
+        return ids
+
+    def zone_bypass_allowed(self, zone_id: int) -> bool:
+        """Whether panel config and zone type allow bypassing this zone.
+
+        The panel-side "forbid bypass on arming" setting and the zone
+        type always win over the HA-side configuration.
+        """
+        if self.zone_forbids_bypass(zone_id):
+            return False
+        zone = (self.coordinator.zones or {}).get(zone_id)
+        return zone is None or is_auto_bypass_eligible(zone)
+
+    def bypassable_zone_ids(self, mode: str, force: bool = False) -> set[int]:
+        """Effective bypassable zone ids for one arming mode.
+
+        ``force`` ignores the per-mode auto-bypass switch, for the
+        explicit ``arm_*_with_bypass`` services: the user asked for the
+        bypass on this call, so only the panel-side restrictions apply.
+        """
+        if not force and mode not in self.auto_bypass_modes:
+            return set()
+        return {
+            zone_id
+            for zone_id in self._configured_bypassable(mode)
+            if self.zone_bypass_allowed(zone_id)
+        }
+
+    @property
+    def debounce_seconds(self) -> int:
+        """How long a zone must stay healthy before re-enable."""
+        return int(
+            self.entry.data.get(
+                CONF_BYPASS_REENABLE_DEBOUNCE, DEFAULT_BYPASS_REENABLE_DEBOUNCE
+            )
+        )
+
+    @property
+    def clear_all_on_disarm(self) -> bool:
+        """Whether disarm cleanup extends to all bypasses."""
+        return bool(self.entry.data.get(CONF_CLEAR_ALL_ON_DISARM, False))
+
+    def is_bypassable(self, zone_id: int, mode: str = ARM_MODE_AWAY) -> bool:
+        """Whether the zone may actually be auto-bypassed in one mode.
+
+        False when the mode itself has auto-bypass switched off, when the
+        zone was not picked for that mode, or when the panel forbids it.
+        """
+        return zone_id in self.bypassable_zone_ids(mode)
+
+    def is_configured_bypassable(
+        self, zone_id: int, mode: str = ARM_MODE_AWAY
+    ) -> bool:
+        """Whether the user picked the zone for one mode, ignoring gating."""
+        return zone_id in self._configured_bypassable(mode)
+
+    def zone_forbids_bypass(self, zone_id: int) -> bool:
+        """Whether the panel config forbids bypassing this zone on arming.
+
+        The panel-side "forbid bypass on arming" (``armNoBypassEnabled``)
+        zone setting always wins over the HA-side bypassable flag: the
+        flag is kept off and its switch is not editable.
+        """
+        config = (self.coordinator.devices or {}).get(zone_id)
+        return config is not None and bool(config.arm_no_bypass_enabled)
+
+    def async_report_ineffective_config(self) -> None:
+        """Warn about configured zones the panel will not let us bypass.
+
+        The configuration is the user's, so it is never rewritten behind
+        their back: a zone the panel forbids simply has no effect, and
+        the reason is logged once per polling cycle change.
+        """
+        ineffective: dict[str, set[int]] = {}
+        for mode in self.auto_bypass_modes:
+            blocked = {
+                zone_id
+                for zone_id in self._configured_bypassable(mode)
+                if not self.zone_bypass_allowed(zone_id)
+            }
+            if blocked:
+                ineffective[mode] = blocked
+        if ineffective == self._reported_ineffective:
+            return
+        self._reported_ineffective = ineffective
+        for mode, blocked in ineffective.items():
+            _LOGGER.warning(
+                "Zones %s are configured as bypassable on %s arming but the "
+                "panel config or their zone type forbids bypassing them; "
+                "they will be treated as blocking",
+                sorted(blocked),
+                mode,
+            )
+
+    # ------------------------------------------------------------------
+    # State views for entities
+
+    def current_readiness(self, mode: str = ARM_MODE_AWAY) -> ReadinessResult:
+        """Readiness for the given mode computed from the latest poll."""
+        zones = list((self.coordinator.zones or {}).values())
+        bypassable = self.bypassable_zone_ids(mode)
+        return evaluate_arm_readiness(zones, bypassable, mode)
+
+    def owns_zone(self, zone_id: int) -> bool:
+        """Whether the current bypass of the zone was applied by us."""
+        return zone_id in self.store.data.owned_bypasses
+
+    def bypass_reason(self, zone_id: int) -> str | None:
+        """Reason of the owned bypass on a zone, if any."""
+        owned = self.store.data.owned_bypasses.get(zone_id)
+        return owned.reason if owned else None
+
+    def diagnostics(self, sub_id: int | None = None) -> dict[str, Any]:
+        """Diagnostic attributes for the alarm panel    ."""
+        zones = (self.coordinator.zones or {}).values()
+        bypassed = [
+            {"zone_id": zone.id, "zone_name": zone.name, "area": zone.sub_system_no}
+            for zone in zones
+            if zone.bypassed and zone_in_area(zone, sub_id)
+        ]
+        owned = {
+            zone_id: {
+                "reason": rec.reason,
+                "applied_at": rec.applied_at.isoformat(),
+                "pending_unbypass": rec.pending_unbypass,
+                "healthy_since": self._healthy_since[zone_id].isoformat()
+                if zone_id in self._healthy_since
+                else None,
+            }
+            for zone_id, rec in self.store.data.owned_bypasses.items()
+            if sub_id is None or rec.area in (None, sub_id)
+        }
+        return {
+            "bypassed_zones": bypassed,
+            "owned_bypasses": owned,
+            "last_auto_bypass": self.store.data.last_auto_bypass.isoformat()
+            if self.store.data.last_auto_bypass
+            else None,
+        }
+
+    # ------------------------------------------------------------------
+    # Arming flow
+
+    async def async_prepare_arming(
+        self, sub_id: int | None, mode: str, force: bool = False
+    ) -> None:
+        """Run the pre-arm bypass flow; raise ArmingBlockedError to abort.
+
+        Must be called while holding ``arm_lock``. No-op when the
+        auto-bypass option is disabled for the requested mode, unless
+        ``force`` is set by an explicit arm-with-bypass service call.
+        """
+        if not force and mode not in self.auto_bypass_modes:
+            return
+        if not self.bypass_supported:
+            _LOGGER.debug("Bypass unsupported by firmware; skipping pre-arm flow")
+            return
+
+        zones = await self._async_fresh_zones()
+        area_zones = [zone for zone in zones if zone_in_area(zone, sub_id)]
+        result = evaluate_arm_readiness(
+            area_zones, self.bypassable_zone_ids(mode, force), mode
+        )
+
+        if result.blocking_zones:
+            self._fire_arming_blocked(sub_id, result.blocking_zones, [])
+            raise ArmingBlockedError(
+                "Arming blocked by faulted non-bypassable zones",
+                zones=self._zone_list_str(result.blocking_zones),
+            )
+
+        arm_flow_id = uuid4().hex[:8]
+        applied: list[dict[str, Any]] = []
+        for issue in result.zones_to_bypass:
+            zone_id: int = issue["zone_id"]
+            # Write-ahead: persist ownership before the command so a crash
+            # can only leave a tracked-but-unapplied entry, which the
+            # reconciliation drops silently.
+            self.store.data.owned_bypasses[zone_id] = OwnedBypass(
+                applied_at=dt_util.utcnow(),
+                reason=REASON_AUTO_ARM,
+                area=issue["area"] if sub_id is None else sub_id,
+                arm_flow_id=arm_flow_id,
+            )
+            await self.store.async_save()
+            try:
+                await self.hass.async_add_executor_job(self.client.bypass, zone_id)
+            except BypassError as err:
+                _LOGGER.error("Bypass of zone %s failed: %s", zone_id, err)
+                self.store.data.owned_bypasses.pop(zone_id, None)
+                await self._async_rollback(applied)
+                failed = [dict(issue, error=str(err))]
+                self._fire_arming_blocked(sub_id, [], failed)
+                raise ArmingBlockedError(
+                    f"Bypass of zone {issue['zone_name']} failed",
+                    zones=str(issue["zone_name"]),
+                ) from err
+            applied.append(issue)
+            self._fire_bypass_event(EVENT_BYPASS_APPLIED, issue, REASON_AUTO_ARM)
+
+        if applied:
+            self.store.data.last_auto_bypass = dt_util.utcnow()
+            await self.store.async_save()
+
+    async def _async_rollback(self, applied: list[dict[str, Any]]) -> None:
+        """Best-effort removal of bypasses applied in this flow."""
+        for issue in reversed(applied):
+            zone_id: int = issue["zone_id"]
+            try:
+                await self.hass.async_add_executor_job(self.client.unbypass, zone_id)
+            except BypassError as err:
+                _LOGGER.error(
+                    "Rollback: could not unbypass zone %s, will retry on disarm: %s",
+                    zone_id,
+                    err,
+                )
+                owned = self.store.data.owned_bypasses.get(zone_id)
+                if owned:
+                    owned.pending_unbypass = True
+            else:
+                self.store.data.owned_bypasses.pop(zone_id, None)
+                self._fire_bypass_event(EVENT_BYPASS_REMOVED, issue, REASON_ROLLBACK)
+        await self.store.async_save()
+
+    async def _async_fresh_zones(self) -> list[Zone]:
+        """Synchronously read fresh zone states; abort arming on failure."""
+        try:
+            async with timeout(FRESH_READ_TIMEOUT):
+                raw = await self.hass.async_add_executor_job(
+                    self.client.fetch_zone_status
+                )
+            response = ZonesResponse.from_dict(raw)
+        except Exception as err:
+            raise ArmingBlockedError(
+                f"Fresh zone state read failed: {err}"
+            ) from err
+        return [wrap.zone for wrap in response.zone_list]
+
+    # ------------------------------------------------------------------
+    # Services
+
+    def _require_supported(self) -> None:
+        if not self.bypass_supported:
+            raise HomeAssistantError(
+                "The panel firmware does not support zone bypass",
+                translation_domain=DOMAIN,
+                translation_key="bypass_unsupported",
+            )
+
+    async def async_bypass_zone(self, zone_id: int, reason: str = REASON_SERVICE) -> None:
+        """Bypass a zone on user request; the bypass is integration-owned."""
+        self._require_supported()
+        async with self.arm_lock:
+            self.store.data.owned_bypasses[zone_id] = OwnedBypass(
+                applied_at=dt_util.utcnow(), reason=reason, area=self._zone_area(zone_id)
+            )
+            await self.store.async_save()
+            try:
+                await self.hass.async_add_executor_job(self.client.bypass, zone_id)
+            except BypassError as err:
+                self.store.data.owned_bypasses.pop(zone_id, None)
+                await self.store.async_save()
+                raise HomeAssistantError(
+                    f"Bypass of zone {zone_id} failed: {err}",
+                    translation_domain=DOMAIN,
+                    translation_key="bypass_failed",
+                    translation_placeholders={"zone": str(zone_id), "error": str(err)},
+                ) from err
+            self._fire_bypass_event(
+                EVENT_BYPASS_APPLIED, self._issue_for(zone_id), reason
+            )
+        await self.coordinator.async_request_refresh()
+
+    async def async_unbypass_zone(
+        self, zone_id: int, reason: str = REASON_SERVICE
+    ) -> None:
+        """Restore a zone on user request."""
+        self._require_supported()
+        async with self.arm_lock:
+            try:
+                await self.hass.async_add_executor_job(self.client.unbypass, zone_id)
+            except BypassError as err:
+                raise HomeAssistantError(
+                    f"Unbypass of zone {zone_id} failed: {err}",
+                    translation_domain=DOMAIN,
+                    translation_key="unbypass_failed",
+                    translation_placeholders={"zone": str(zone_id), "error": str(err)},
+                ) from err
+            self.store.data.owned_bypasses.pop(zone_id, None)
+            self._healthy_since.pop(zone_id, None)
+            self._cancel_reenable(zone_id)
+            await self.store.async_save()
+            self._fire_bypass_event(
+                EVENT_BYPASS_REMOVED, self._issue_for(zone_id), reason
+            )
+        await self.coordinator.async_request_refresh()
+
+    async def async_clear_all(self, sub_id: int | None = None) -> None:
+        """Remove every bypass in the area, regardless of owner."""
+        self._require_supported()
+        async with self.arm_lock:
+            zones = await self._async_fresh_zones_or_error()
+            errors: list[str] = []
+            for zone in zones:
+                if not zone.bypassed or not zone_in_area(zone, sub_id):
+                    continue
+                try:
+                    await self.hass.async_add_executor_job(self.client.unbypass, zone.id)
+                except BypassError as err:
+                    _LOGGER.error("Could not unbypass zone %s: %s", zone.id, err)
+                    errors.append(f"{zone.name}: {err}")
+                    continue
+                self.store.data.owned_bypasses.pop(zone.id, None)
+                self._healthy_since.pop(zone.id, None)
+                self._cancel_reenable(zone.id)
+                self._fire_bypass_event(
+                    EVENT_BYPASS_REMOVED, _zone_issue(zone, ""), REASON_SERVICE
+                )
+            await self.store.async_save()
+            if errors:
+                raise HomeAssistantError(
+                    "Some bypasses could not be removed: " + "; ".join(errors)
+                )
+        await self.coordinator.async_request_refresh()
+
+    async def _async_fresh_zones_or_error(self) -> list[Zone]:
+        try:
+            return await self._async_fresh_zones()
+        except ArmingBlockedError as err:
+            raise HomeAssistantError(str(err)) from err
+
+    # ------------------------------------------------------------------
+    # Lifecycle: disarm cleanup, reconciliation, recovery
+
+    async def async_on_disarm(self, sub_id: int | None) -> None:
+        """Remove owned bypasses after a disarm."""
+        if not self.store.data.owned_bypasses and not self.clear_all_on_disarm:
+            return
+        async with self.arm_lock:
+            await self._async_disarm_cleanup(sub_id)
+
+    async def _async_disarm_cleanup(self, sub_id: int | None) -> None:
+        try:
+            zones = {zone.id: zone for zone in await self._async_fresh_zones()}
+        except ArmingBlockedError as err:
+            _LOGGER.warning("Disarm cleanup: fresh read failed, will retry: %s", err)
+            return
+
+        for zone_id in list(self.store.data.owned_bypasses):
+            zone = zones.get(zone_id)
+            in_area = zone is None or zone_in_area(zone, sub_id)
+            if not in_area:
+                continue
+            if zone is None or not zone.bypassed:
+                # Already removed on the panel side: reconcile silently.
+                self.store.data.owned_bypasses.pop(zone_id, None)
+                continue
+            try:
+                await self.hass.async_add_executor_job(self.client.unbypass, zone_id)
+            except BypassError as err:
+                _LOGGER.error(
+                    "Disarm cleanup: could not unbypass zone %s: %s", zone_id, err
+                )
+                owned = self.store.data.owned_bypasses.get(zone_id)
+                if owned:
+                    owned.pending_unbypass = True
+                continue
+            self.store.data.owned_bypasses.pop(zone_id, None)
+            self._fire_bypass_event(
+                EVENT_BYPASS_REMOVED, _zone_issue(zone, ""), REASON_DISARM
+            )
+            self._healthy_since.pop(zone_id, None)
+            self._cancel_reenable(zone_id)
+
+        if self.clear_all_on_disarm:
+            for zone in zones.values():
+                if not zone.bypassed or not zone_in_area(zone, sub_id):
+                    continue
+                if zone.id in self.store.data.owned_bypasses:
+                    continue
+                try:
+                    await self.hass.async_add_executor_job(self.client.unbypass, zone.id)
+                except BypassError as err:
+                    _LOGGER.error(
+                        "Disarm cleanup (all): could not unbypass zone %s: %s",
+                        zone.id,
+                        err,
+                    )
+                    continue
+                self._fire_bypass_event(
+                    EVENT_BYPASS_REMOVED, _zone_issue(zone, ""), REASON_DISARM
+                )
+        await self.store.async_save()
+
+    async def async_on_data_refreshed(self) -> None:
+        """React to a completed polling cycle."""
+        self._detect_external_disarm()
+        if self.arm_lock.locked():
+            return
+        self.async_report_ineffective_config()
+        await self._async_reconcile()
+        self._observe_recovery()
+
+    def _detect_external_disarm(self) -> None:
+        """Trigger cleanup when an area was disarmed outside HA."""
+        current: dict[int, Arming | None] = {
+            sub_id: sub.arming for sub_id, sub in self.coordinator.sub_systems.items()
+        }
+        for sub_id, arming in current.items():
+            previous = self._last_arming.get(sub_id)
+            if (
+                previous is not None
+                and previous != Arming.DISARM
+                and arming == Arming.DISARM
+            ):
+                _LOGGER.debug("Area %s disarmed externally; scheduling cleanup", sub_id)
+                self.hass.async_create_task(self.async_on_disarm(sub_id))
+        self._last_arming = current
+
+    async def _async_reconcile(self) -> None:
+        """Drop tracking of bypasses removed on the panel side."""
+        zones = self.coordinator.zones or {}
+        now = dt_util.utcnow()
+        changed = False
+        for zone_id in list(self.store.data.owned_bypasses):
+            owned = self.store.data.owned_bypasses[zone_id]
+            if (now - owned.applied_at).total_seconds() < RECONCILE_GRACE_SECONDS:
+                continue
+            zone = zones.get(zone_id)
+            if zone is None or zone.bypassed:
+                continue
+            _LOGGER.info(
+                "Owned bypass of zone %s was removed on the panel; updating tracking",
+                zone_id,
+            )
+            self.store.data.owned_bypasses.pop(zone_id, None)
+            self._healthy_since.pop(zone_id, None)
+            self._cancel_reenable(zone_id)
+            self._fire_bypass_event(
+                EVENT_BYPASS_REMOVED, self._issue_for(zone_id), REASON_RECONCILED
+            )
+            changed = True
+        if changed:
+            self.store.async_delay_save()
+
+    def _observe_recovery(self) -> None:
+        """Track health of owned bypasses and schedule re-enable."""
+        zones = self.coordinator.zones or {}
+        now = dt_util.utcnow()
+        for zone_id in list(self.store.data.owned_bypasses):
+            zone = zones.get(zone_id)
+            if zone is None:
+                continue
+            fault = zone_fault_reason(zone)
+            if fault is not None:
+                # Still in fault: never re-enable; reset debounce.
+                if self._healthy_since.pop(zone_id, None) is not None:
+                    _LOGGER.info(
+                        "Bypassed zone %s (%s) went back to fault (%s); "
+                        "re-enable cancelled",
+                        zone_id,
+                        zone.name,
+                        fault,
+                    )
+                self._cancel_reenable(zone_id)
+                continue
+            if not self._zone_area_armed(zone):
+                _LOGGER.debug(
+                    "Bypassed zone %s healthy but its area is not armed; "
+                    "leaving it to the disarm cleanup",
+                    zone_id,
+                )
+                continue
+            if zone_id not in self._healthy_since:
+                self._healthy_since[zone_id] = now
+                _LOGGER.info(
+                    "Bypassed zone %s (%s) recovered while armed; "
+                    "re-enabling in %s seconds if it stays healthy",
+                    zone_id,
+                    zone.name,
+                    self.debounce_seconds,
+                )
+            since = self._healthy_since[zone_id]
+            remaining = self.debounce_seconds - (now - since).total_seconds()
+            if remaining <= 0:
+                self._cancel_reenable(zone_id)
+                self.hass.async_create_task(self._async_try_reenable(zone_id))
+            elif zone_id not in self._reenable_unsub:
+                self._schedule_reenable(zone_id, remaining)
+
+    def _schedule_reenable(self, zone_id: int, delay: float) -> None:
+        @callback
+        def _fire(_now: datetime) -> None:
+            self._reenable_unsub.pop(zone_id, None)
+            self.hass.async_create_task(self._async_try_reenable(zone_id))
+
+        self._reenable_unsub[zone_id] = async_call_later(self.hass, delay + 0.5, _fire)
+
+    def _cancel_reenable(self, zone_id: int) -> None:
+        if unsub := self._reenable_unsub.pop(zone_id, None):
+            unsub()
+
+    async def _async_try_reenable(self, zone_id: int) -> None:
+        """Remove an owned bypass once the zone proved healthy."""
+        if self.arm_lock.locked():
+            return  # an arm/bypass flow is running; the next poll retries
+        async with self.arm_lock:
+            owned = self.store.data.owned_bypasses.get(zone_id)
+            if owned is None:
+                return
+            if zone_id not in self._healthy_since:
+                # The zone went unhealthy again before the timer fired.
+                return
+            # Never act on stale data: re-read the zone right before removal.
+            try:
+                raw = await self.hass.async_add_executor_job(
+                    self.client.get_zone_raw, zone_id
+                )
+            except BypassError as err:
+                _LOGGER.warning(
+                    "Re-enable of zone %s postponed, fresh state read failed "
+                    "(next poll retries): %s",
+                    zone_id,
+                    err,
+                )
+                return
+            if raw is None:
+                _LOGGER.warning(
+                    "Re-enable of zone %s postponed: zone missing from the "
+                    "panel status response",
+                    zone_id,
+                )
+                return
+            zone = Zone.from_dict(raw)
+            if not zone.bypassed:
+                # Already restored externally; reconciliation on next poll.
+                return
+            fault = zone_fault_reason(zone)
+            if fault is not None:
+                _LOGGER.info(
+                    "Re-enable of zone %s aborted: fresh read shows it in "
+                    "fault again (%s)",
+                    zone_id,
+                    fault,
+                )
+                self._healthy_since.pop(zone_id, None)
+                return
+            if not self._zone_area_armed(zone):
+                return
+            try:
+                await self.hass.async_add_executor_job(self.client.unbypass, zone_id)
+            except BypassError as err:
+                _LOGGER.warning(
+                    "Panel refused to unbypass zone %s while armed; "
+                    "will retry and clean up on disarm: %s",
+                    zone_id,
+                    err,
+                )
+                owned.pending_unbypass = True
+                await self.store.async_save()
+                return
+            self.store.data.owned_bypasses.pop(zone_id, None)
+            self._healthy_since.pop(zone_id, None)
+            await self.store.async_save()
+            _LOGGER.info(
+                "Zone %s (%s) re-enabled after recovery: it is armed again",
+                zone_id,
+                zone.name,
+            )
+            self._fire_bypass_event(
+                EVENT_BYPASS_REMOVED, _zone_issue(zone, ""), REASON_HEALTH_RECOVERED
+            )
+        await self.coordinator.async_request_refresh()
+
+    def _zone_area_armed(self, zone: Zone) -> bool:
+        """Whether the area the zone belongs to is currently armed."""
+        area = zone.sub_system_no
+        if area is not None and area in self.coordinator.sub_systems:
+            arming = self.coordinator.sub_systems[area].arming
+            return arming not in (Arming.DISARM, None)
+        state = self.coordinator.state
+        return state is not None and str(state) not in ("disarmed",)
+
+    def async_unload(self) -> None:
+        """Cancel timers on entry unload."""
+        for zone_id in list(self._reenable_unsub):
+            self._cancel_reenable(zone_id)
+
+    # ------------------------------------------------------------------
+    # Helpers
+
+    def _zone_area(self, zone_id: int) -> int | None:
+        zone = (self.coordinator.zones or {}).get(zone_id)
+        return zone.sub_system_no if zone else None
+
+    def _issue_for(self, zone_id: int) -> dict[str, Any]:
+        zone = (self.coordinator.zones or {}).get(zone_id)
+        if zone is not None:
+            return _zone_issue(zone, "")
+        return {"zone_id": zone_id, "zone_name": None, "area": None, "fault": ""}
+
+    def _fire_bypass_event(
+        self, event: str, issue: dict[str, Any], reason: str
+    ) -> None:
+        self.hass.bus.async_fire(
+            event,
+            {
+                "entry_id": self.entry.entry_id,
+                "device_name": self.coordinator.device_name,
+                "zone_id": issue["zone_id"],
+                "zone_name": issue["zone_name"],
+                "area": issue["area"],
+                "reason": reason,
+            },
+        )
+
+    def _fire_arming_blocked(
+        self,
+        sub_id: int | None,
+        blocking: list[dict[str, Any]],
+        failed: list[dict[str, Any]],
+    ) -> None:
+        self.hass.bus.async_fire(
+            EVENT_ARMING_BLOCKED,
+            {
+                "entry_id": self.entry.entry_id,
+                "device_name": self.coordinator.device_name,
+                "area": sub_id,
+                "blocking_zones": blocking,
+                "failed_bypass_zones": failed,
+            },
+        )
+
+    @staticmethod
+    def _zone_list_str(issues: list[dict[str, Any]]) -> str:
+        return ", ".join(
+            f"{issue['zone_name']} ({issue['fault']})" for issue in issues
+        )

--- a/custom_components/hikvision_axpro/bypass_store.py
+++ b/custom_components/hikvision_axpro/bypass_store.py
@@ -1,0 +1,119 @@
+"""Persistent storage for the zone bypass feature.
+
+Tracks the bypasses this integration applied itself, so they can be
+recognised, reconciled and removed again across Home Assistant
+restarts. Which zones *may* be bypassed is configuration, not state, and
+lives in the config entry instead.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+
+from .const import DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
+
+STORAGE_VERSION = 1
+SAVE_DELAY = 1.0
+
+
+@dataclass
+class OwnedBypass:
+    """A bypass applied by this integration."""
+
+    applied_at: datetime
+    reason: str
+    area: int | None = None
+    arm_flow_id: str | None = None
+    pending_unbypass: bool = False
+
+    def as_dict(self) -> dict:
+        """Serialize for storage."""
+        return {
+            "applied_at": self.applied_at.isoformat(),
+            "reason": self.reason,
+            "area": self.area,
+            "arm_flow_id": self.arm_flow_id,
+            "pending_unbypass": self.pending_unbypass,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> OwnedBypass:
+        """Deserialize from storage."""
+        applied_at = dt_util.parse_datetime(data.get("applied_at") or "")
+        return cls(
+            applied_at=applied_at or dt_util.utcnow(),
+            reason=data.get("reason", "unknown"),
+            area=data.get("area"),
+            arm_flow_id=data.get("arm_flow_id"),
+            pending_unbypass=bool(data.get("pending_unbypass", False)),
+        )
+
+
+@dataclass
+class BypassData:
+    """In-memory view of the stored bypass state."""
+
+    owned_bypasses: dict[int, OwnedBypass] = field(default_factory=dict)
+    last_auto_bypass: datetime | None = None
+
+
+class BypassStore:
+    """Typed wrapper over a Home Assistant Store."""
+
+    def __init__(self, hass: HomeAssistant, entry_id: str) -> None:
+        """Initialize the store for a config entry."""
+        self._store: Store = Store(
+            hass,
+            STORAGE_VERSION,
+            f"{DOMAIN}.{entry_id}.bypass",
+        )
+        self.data = BypassData()
+
+    async def async_load(self) -> None:
+        """Load stored data, starting fresh if it cannot be read.
+
+        Everything kept here is recoverable: the owned bypasses are
+        re-derived by the reconciliation on the next poll. A missing,
+        corrupt, or newer-than-expected file is therefore not worth
+        failing the setup over.
+        """
+        try:
+            raw = await self._store.async_load()
+            if not raw:
+                return
+            self.data.owned_bypasses = {
+                int(zone_id): OwnedBypass.from_dict(owned)
+                for zone_id, owned in (raw.get("owned_bypasses") or {}).items()
+            }
+            last = raw.get("last_auto_bypass")
+            self.data.last_auto_bypass = dt_util.parse_datetime(last) if last else None
+        except Exception as err:  # noqa: BLE001 - never block setup on state
+            _LOGGER.warning("Discarding unreadable bypass storage: %s", err)
+            self.data = BypassData()
+
+    def _as_dict(self) -> dict:
+        return {
+            "owned_bypasses": {
+                str(zone_id): owned.as_dict()
+                for zone_id, owned in self.data.owned_bypasses.items()
+            },
+            "last_auto_bypass": self.data.last_auto_bypass.isoformat()
+            if self.data.last_auto_bypass
+            else None,
+        }
+
+    async def async_save(self) -> None:
+        """Save immediately (used as write-ahead before bypass commands)."""
+        await self._store.async_save(self._as_dict())
+
+    def async_delay_save(self) -> None:
+        """Schedule a delayed save for non-critical mutations."""
+        self._store.async_delay_save(self._as_dict, SAVE_DELAY)

--- a/custom_components/hikvision_axpro/config_flow.py
+++ b/custom_components/hikvision_axpro/config_flow.py
@@ -20,10 +20,40 @@ from homeassistant.const import (
     CONF_SCAN_INTERVAL,
 )
 from homeassistant.components.alarm_control_panel import SCAN_INTERVAL
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.selector import (
+    EntitySelector,
+    EntitySelectorConfig,
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
-from .const import DOMAIN, USE_CODE_ARMING, ALLOW_SUBSYSTEMS, ENABLE_DEBUG_OUTPUT, AUTO_BYPASS_ON_ARM
+from .const import (
+    ALLOW_SUBSYSTEMS,
+    ARM_MODES,
+    DATA_BYPASS_MANAGER,
+    CONF_AUTO_BYPASS_MODES,
+    CONF_BYPASS_REENABLE_DEBOUNCE,
+    CONF_CLEAR_ALL_ON_DISARM,
+    DEFAULT_BYPASS_REENABLE_DEBOUNCE,
+    DOMAIN,
+    ENABLE_DEBUG_OUTPUT,
+    USE_CODE_ARMING,
+    conf_bypassable_zones,
+    zone_id_from_bypass_unique_id,
+)
 
 _LOGGER = logging.getLogger(__name__)
+
+AUTO_BYPASS_MODES_SELECTOR = SelectSelector(
+    SelectSelectorConfig(
+        options=ARM_MODES,
+        multiple=True,
+        mode=SelectSelectorMode.LIST,
+        translation_key="auto_bypass_modes",
+    )
+)
 
 STEP_USER_DATA_SCHEMA = vol.Schema(
     {
@@ -36,7 +66,11 @@ STEP_USER_DATA_SCHEMA = vol.Schema(
         vol.Optional(USE_CODE_ARMING, default=False): bool,
         vol.Required(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL.total_seconds()): int,
         vol.Optional(ALLOW_SUBSYSTEMS, default=False): bool,
-        vol.Optional(AUTO_BYPASS_ON_ARM, default=False): bool,
+        vol.Optional(CONF_AUTO_BYPASS_MODES, default=[]): AUTO_BYPASS_MODES_SELECTOR,
+        vol.Optional(
+            CONF_BYPASS_REENABLE_DEBOUNCE, default=DEFAULT_BYPASS_REENABLE_DEBOUNCE
+        ): vol.All(int, vol.Range(min=0, max=300)),
+        vol.Optional(CONF_CLEAR_ALL_ON_DISARM, default=False): bool,
     }
 )
 
@@ -52,7 +86,11 @@ CONFIGURE_SCHEMA = vol.Schema(
         vol.Optional(USE_CODE_ARMING, default=False): bool,
         vol.Required(CONF_SCAN_INTERVAL, default=SCAN_INTERVAL.total_seconds()): int,
         vol.Optional(ALLOW_SUBSYSTEMS, default=False): bool,
-        vol.Optional(AUTO_BYPASS_ON_ARM, default=False): bool,
+        vol.Optional(CONF_AUTO_BYPASS_MODES, default=[]): AUTO_BYPASS_MODES_SELECTOR,
+        vol.Optional(
+            CONF_BYPASS_REENABLE_DEBOUNCE, default=DEFAULT_BYPASS_REENABLE_DEBOUNCE
+        ): vol.All(int, vol.Range(min=0, max=300)),
+        vol.Optional(CONF_CLEAR_ALL_ON_DISARM, default=False): bool,
         vol.Optional(ENABLE_DEBUG_OUTPUT, default=False): bool,
     }
 )
@@ -177,6 +215,107 @@ class AxProOptionsFlowHandler(config_entries.OptionsFlow):
 
     def __init__(self):
         """Initialize AxPro options flow."""
+        self._pending: dict[str, Any] = {}
+        self._title: str = ""
+
+    def _zone_bypass_entities(self) -> dict[str, int]:
+        """Map this panel's bypassable zone entities to their zone id.
+
+        Only entities belonging to this config entry are offered, so the
+        picker can never reach another panel's zones, and only zones the
+        panel would actually let us bypass on arming: a zone whose type
+        is not eligible, or whose "forbid bypass on arming" setting is
+        on, is left out rather than offered and then silently ignored.
+        """
+        registry = er.async_get(self.hass)
+        manager = (
+            self.hass.data.get(DOMAIN, {})
+            .get(self.config_entry.entry_id, {})
+            .get(DATA_BYPASS_MANAGER)
+        )
+        entities: dict[str, int] = {}
+        for reg_entry in er.async_entries_for_config_entry(
+            registry, self.config_entry.entry_id
+        ):
+            zone_id = zone_id_from_bypass_unique_id(reg_entry.unique_id)
+            if zone_id is None:
+                continue
+            if manager is not None and not manager.zone_bypass_allowed(zone_id):
+                continue
+            entities[reg_entry.entity_id] = zone_id
+        return entities
+
+    def _bypass_zones_schema(self, modes: list[str]) -> vol.Schema:
+        """One entity multiselect per arming mode with auto-bypass on."""
+        available = self._zone_bypass_entities()
+        by_zone = {zone_id: entity_id for entity_id, zone_id in available.items()}
+        selector = EntitySelector(
+            EntitySelectorConfig(
+                multiple=True,
+                include_entities=sorted(available),
+            )
+        )
+        fields: dict[Any, Any] = {}
+        for mode in ARM_MODES:
+            if mode not in modes:
+                continue
+            key = conf_bypassable_zones(mode)
+            # Stored as zone ids so a renamed entity never loses its
+            # configuration; shown as the entities they belong to.
+            current = [
+                by_zone[zone_id]
+                for zone_id in self.config_entry.data.get(key) or []
+                if zone_id in by_zone
+            ]
+            fields[vol.Optional(key, default=current)] = selector
+        return vol.Schema(fields)
+
+    async def async_step_bypass_zones(self, user_input=None):
+        """Pick which zones the auto-bypass may bypass, per arming mode."""
+        modes = [
+            mode
+            for mode in ARM_MODES
+            if mode in (self._pending.get(CONF_AUTO_BYPASS_MODES) or [])
+        ]
+
+        if user_input is None:
+            return self.async_show_form(
+                step_id="bypass_zones",
+                data_schema=self._bypass_zones_schema(modes),
+                last_step=True,
+            )
+
+        available = self._zone_bypass_entities()
+        data = dict(self._pending)
+        for mode in ARM_MODES:
+            key = conf_bypassable_zones(mode)
+            if mode not in modes:
+                # Auto-bypass is off for this mode: forget its selection
+                # rather than keeping a hidden one that would come back.
+                data.pop(key, None)
+                continue
+            data[key] = sorted(
+                {
+                    available[entity_id]
+                    for entity_id in user_input.get(key) or []
+                    if entity_id in available
+                }
+            )
+        return self._save(data)
+
+    def _save(self, data: dict[str, Any]):
+        """Persist the collected options onto the config entry."""
+        _LOGGER.debug("Saving options %s %s", self._title, data)
+        self.hass.config_entries.async_update_entry(self.config_entry, data=data)
+        return self.async_create_entry(title=self._title, data=data)
+
+    def _zone_step_follows(self, defaults: dict[str, Any]) -> bool:
+        """Whether submitting the first page opens the zone picker.
+
+        Drives the button label: Home Assistant renders "Next" instead
+        of "Submit" when the form says it is not the last step.
+        """
+        return bool(defaults.get(CONF_AUTO_BYPASS_MODES))
 
     async def async_step_init(self, user_input=None):
         """Manage basic options."""
@@ -187,6 +326,7 @@ class AxProOptionsFlowHandler(config_entries.OptionsFlow):
             return self.async_show_form(
                 step_id="init",
                 data_schema=schema_defaults(CONFIGURE_SCHEMA, **defaults),
+                last_step=not self._zone_step_follows(defaults),
             )
         errors = {}
 
@@ -204,17 +344,21 @@ class AxProOptionsFlowHandler(config_entries.OptionsFlow):
             _LOGGER.exception("Unexpected exception")
             errors["base"] = "unknown"
         else:
-            _LOGGER.debug("Saving options %s %s",info["title"], user_input)
-
-            self.hass.config_entries.async_update_entry(
-                self.config_entry,
-                data=user_input,
-            )
-            return self.async_create_entry(title=info["title"], data=user_input)
+            # Carry over settings the form does not expose (the stored
+            # bypassable zone ids), then let the next step revise them.
+            data = {**self.config_entry.data, **user_input}
+            self._pending = data
+            self._title = info["title"]
+            if user_input.get(CONF_AUTO_BYPASS_MODES):
+                return await self.async_step_bypass_zones()
+            for mode in ARM_MODES:
+                data.pop(conf_bypassable_zones(mode), None)
+            return self._save(data)
 
         return self.async_show_form(
             step_id="init",
             data_schema=schema_defaults(CONFIGURE_SCHEMA, None, **defaults),
+            last_step=not self._zone_step_follows(defaults),
             errors=errors
         )
 

--- a/custom_components/hikvision_axpro/const.py
+++ b/custom_components/hikvision_axpro/const.py
@@ -1,10 +1,13 @@
 """Constants for the hikvision_axpro integration."""
 
+import re
 from typing import Final
 
 DOMAIN: Final[str] = "hikvision_axpro"
 
 DATA_COORDINATOR: Final[str] = "hikaxpro"
+
+DATA_BYPASS_MANAGER: Final[str] = "bypass_manager"
 
 USE_CODE_ARMING: Final[str] = "use_code_arming"
 
@@ -12,7 +15,50 @@ ALLOW_SUBSYSTEMS: Final[str] = "allow_subsystems"
 
 ENABLE_DEBUG_OUTPUT: Final[str] = "debug"
 
-AUTO_BYPASS_ON_ARM: Final[str] = "auto_bypass_on_arm"
+# Arming modes, aligned with the Home Assistant arm actions
+ARM_MODE_HOME: Final[str] = "home"
+ARM_MODE_AWAY: Final[str] = "away"
+ARM_MODE_VACATION: Final[str] = "vacation"
+ARM_MODES: Final[list[str]] = [ARM_MODE_HOME, ARM_MODE_AWAY, ARM_MODE_VACATION]
+
+# Zone bypass feature
+CONF_AUTO_BYPASS_MODES: Final[str] = "auto_bypass_modes"
+CONF_BYPASS_REENABLE_DEBOUNCE: Final[str] = "bypass_reenable_debounce"
+CONF_CLEAR_ALL_ON_DISARM: Final[str] = "clear_all_bypasses_on_disarm"
+
+DEFAULT_BYPASS_REENABLE_DEBOUNCE: Final[int] = 10
+
+
+def conf_bypassable_zones(mode: str) -> str:
+    """Config entry key holding the bypassable zone ids for one mode."""
+    return f"bypassable_zones_{mode}"
+
+
+# unique_id suffix of the per-zone "Bypass" binary sensor. Both the
+# options flow picker and the zone-targeting services resolve an entity
+# back to its zone through it.
+_BYPASS_UNIQUE_ID_RE: Final = re.compile(r"-bypass-(\d+)$")
+
+
+def zone_id_from_bypass_unique_id(unique_id: str | None) -> int | None:
+    """Zone id behind a per-zone bypass binary sensor, or None."""
+    if not unique_id:
+        return None
+    match = _BYPASS_UNIQUE_ID_RE.search(unique_id)
+    return int(match.group(1)) if match else None
+
+# Services
+SERVICE_BYPASS_ZONE: Final[str] = "bypass_zone"
+SERVICE_UNBYPASS_ZONE: Final[str] = "unbypass_zone"
+SERVICE_CLEAR_ALL_BYPASSES: Final[str] = "clear_all_bypasses"
+
+# Events
+EVENT_BYPASS_APPLIED: Final[str] = f"{DOMAIN}_bypass_applied"
+EVENT_BYPASS_REMOVED: Final[str] = f"{DOMAIN}_bypass_removed"
+EVENT_ARMING_BLOCKED: Final[str] = f"{DOMAIN}_arming_blocked"
+
+# Repair issue id for firmware without bypass support
+ISSUE_BYPASS_UNSUPPORTED: Final[str] = "bypass_unsupported"
 
 
 # Sensor entity description constants

--- a/custom_components/hikvision_axpro/entity_id.py
+++ b/custom_components/hikvision_axpro/entity_id.py
@@ -1,19 +1,34 @@
-"""Helpers for valid Home Assistant object/entity IDs."""
+"""Helpers for valid, predictable Home Assistant object/entity IDs.
+
+Every entity id is derived from that entity's ``unique_id``, so the two
+never drift apart and the id is unique by construction: no numeric
+``_2`` suffixes appear when two panels carry zones with the same name.
+An underscore only ever separates two distinct pieces of information —
+the panel MAC stays one compact token, and the trailing number is the
+zone (or area, battery, siren…) the entity belongs to::
+
+    a4d5c26bb859-tamper-1  ->  binary_sensor.a4d5c26bb859_tamper_1
+"""
 
 from __future__ import annotations
 
 from hashlib import sha1
-import logging
 import re
 
-from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
-from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-_LOGGER = logging.getLogger(__name__)
-
 INVALID_OBJECT_ID_RE = re.compile(r"[^a-z0-9_]")
+
+
+def normalized_mac(mac: str | None) -> str:
+    """Return the MAC as one compact token: ``a4d5c26bb859``.
+
+    Separators carry no information here, and spelling the MAC out as
+    ``a4:d5:...`` (or, once slugified, ``a4_d5_...``) turns a single
+    identifier into six. Keeping it compact leaves ``_`` free to
+    separate genuinely different parts of an id.
+    """
+    return re.sub(r"[^a-z0-9]", "", (mac or "").lower())
 
 
 def normalized_object_id(value: str | None, fallback: str | None = None) -> str:
@@ -42,41 +57,65 @@ def has_invalid_object_id_chars(entity_id: str) -> bool:
     return bool(INVALID_OBJECT_ID_RE.search(object_id))
 
 
-def build_entity_id(domain: str, device_name: str | None, *parts: object) -> str:
-    """Build a valid entity_id: ``{domain}.{device}_{suffix}_{id}``.
+def build_entity_id(
+    domain: str,
+    unique_id: str | None,
+    mac_id: str,
+    device_name: str | None = None,
+    number_marker: str = "",
+) -> str:
+    """Build ``<domain>.<device>_z<zone>_<name>_<compact mac>``.
 
-    Example: ``sensor.ax_pro_temperature_0``.
+    The parts come from the entity's own ``unique_id``, which is
+    ``<compact mac>-<name>[-<number>]``, so the id is unique by
+    construction and Home Assistant never has to disambiguate with a
+    ``_2`` suffix when two panels carry zones of the same name.
+
+A zone number is written ``z1`` rather than left bare, so it reads
+    as a zone and can never be mistaken for one of those dedup suffixes.
+    ``number_marker`` is what the number counts, so it is only ``"z"``
+    for entities that really belong to a zone — a hub battery or a relay
+    keeps its own plain number. The number sits next to the device it
+    qualifies and the id ends on the MAC that says which panel::
+
+        ingresso + a4d5c26bb859-tamper-1      (zone)
+            -> binary_sensor.ingresso_z1_tamper_a4d5c26bb859
+        alarm    + a4d5c26bb859-hub-battery-1 (not a zone)
+            -> sensor.alarm_hub_battery_1_a4d5c26bb859
+        alarm    + a4d5c26bb859-ac-power      (nothing numbered)
+            -> binary_sensor.alarm_ac_power_a4d5c26bb859
+
+    Only new entities are affected: Home Assistant keeps whatever
+    entity_id the registry already holds for a known unique_id, so an
+    existing installation — including hand-picked ids — is left as is.
     """
-    object_parts = [normalized_object_id(device_name, fallback="axpro")]
-    for part in parts:
-        if part is None:
-            continue
-        object_parts.append(normalized_object_id(str(part)))
-    return f"{domain}.{'_'.join(object_parts)}"
+    tokens = [t for t in normalized_object_id(unique_id).split("_") if t]
+    mac_token = normalized_object_id(mac_id)
 
+    # Drop the MAC wherever it sits; it is re-appended at the end.
+    rest = [t for t in tokens if t != mac_token]
 
-def migrate_invalid_entity_ids(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Rename registry entries whose object_id is not a valid HA slug."""
-    registry = er.async_get(hass)
-    for entity in er.async_entries_for_config_entry(registry, entry.entry_id):
-        if not has_invalid_object_id_chars(entity.entity_id):
-            continue
+    # A trailing run of digits identifies the zone / area / device.
+    numbers: list[str] = []
+    while rest and rest[-1].isdigit():
+        numbers.insert(0, rest.pop())
 
-        domain, object_id = entity.entity_id.split(".", 1)
-        new_object_id = normalized_object_id(object_id)
-        new_entity_id = f"{domain}.{new_object_id}"
+    device = [t for t in slugify(device_name or "").split("_") if t]
+    # A device already named after what the entity reports would repeat
+    # itself ("front door alarm" + "alarm"); keep the leading copy only.
+    while device and rest and device[-1] == rest[0]:
+        rest.pop(0)
+    # Likewise when the device name already ends in the number, as area
+    # panels do ("Area 1" + area 1): no need to say it twice.
+    while device and numbers and device[-1] == numbers[0]:
+        numbers.pop(0)
 
-        if new_entity_id == entity.entity_id:
-            continue
-
-        if registry.async_get(new_entity_id) is not None:
-            # Avoid clobbering an existing entity; append a short unique suffix.
-            new_entity_id = f"{domain}.{new_object_id}_{entity.unique_id[-6:]}"
-            new_entity_id = (
-                f"{domain}.{normalized_object_id(new_entity_id.split('.', 1)[1])}"
-            )
-
-        _LOGGER.info(
-            "Migrating invalid entity_id %s -> %s", entity.entity_id, new_entity_id
-        )
-        registry.async_update_entity(entity.entity_id, new_entity_id=new_entity_id)
+    if number_marker:
+        # A marked number leads, right after the device it qualifies.
+        parts = [*device, *(f"{number_marker}{n}" for n in numbers), *rest]
+    else:
+        # An unmarked number stays attached to what it counts.
+        parts = [*device, *rest, *numbers]
+    if mac_token:
+        parts.append(mac_token)
+    return f"{domain}.{'_'.join(parts)}"

--- a/custom_components/hikvision_axpro/hik_device.py
+++ b/custom_components/hikvision_axpro/hik_device.py
@@ -6,10 +6,11 @@ Understands zone and custom refID
 from homeassistant.helpers.entity import DeviceInfo
 
 from .const import DOMAIN
+from .entity_id import build_entity_id
 from .model import Zone
 
 
-class HikDevice:
+class HikDevice():
     """Hik device as base for all sensors from HikVision.
 
     Understands zone and custom refID
@@ -29,3 +30,13 @@ class HikDevice:
             # model="Unknown" if self.zone.model is not "0x00001" else self.zone.model,
             sw_version=self.zone.version,
         )
+
+    @property
+    def _object_id_device_name(self) -> str | None:
+        """Device name to strip, falling back to the zone name.
+
+        The registry device entry is only available once the entity has
+        been added; before that the zone name is the device name this
+        integration asks Home Assistant to create.
+        """
+        return super()._object_id_device_name or self.zone.name

--- a/custom_components/hikvision_axpro/host_entities.py
+++ b/custom_components/hikvision_axpro/host_entities.py
@@ -88,14 +88,14 @@ class HikAcPowerBinary(HikPanelEntity, BinarySensorEntity):
         self, coordinator: HikAxProDataUpdateCoordinator, entry_id: str
     ) -> None:
         super().__init__(coordinator, entry_id)
-        self._attr_unique_id = f"{coordinator.device_name}-ac-power"
+        self._attr_unique_id = f"{coordinator.mac_id}-ac-power"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = "AC power"
         self._attr_has_entity_name = True
         self._attr_device_class = BinarySensorDeviceClass.POWER
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN, coordinator.device_name, "ac_power"
-        )
 
     def _is_on(self) -> bool | None:
         data = self.coordinator.ac_power_status
@@ -127,13 +127,13 @@ class HikHostStatusSensor(HikPanelEntity, SensorEntity):
         self, coordinator: HikAxProDataUpdateCoordinator, entry_id: str
     ) -> None:
         super().__init__(coordinator, entry_id)
-        self._attr_unique_id = f"{coordinator.device_name}-host-status"
+        self._attr_unique_id = f"{coordinator.mac_id}-host-status"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = "Host status"
         self._attr_has_entity_name = True
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "host_status"
-        )
 
     def _value(self) -> str | None:
         data = self.coordinator.host_status
@@ -182,7 +182,10 @@ class HikHubBatteryPercent(HikPanelEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
-        self._attr_unique_id = f"{coordinator.device_name}-hub-battery-{battery_id}"
+        self._attr_unique_id = f"{coordinator.mac_id}-hub-battery-{battery_id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
+        )
         self._attr_name = (
             "Hub battery" if battery_id in (0, 1) else f"Hub battery {battery_id}"
         )
@@ -191,9 +194,6 @@ class HikHubBatteryPercent(HikPanelEntity, SensorEntity):
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -221,7 +221,10 @@ class HikHubBatteryStatus(HikPanelEntity, SensorEntity):
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
         self._attr_unique_id = (
-            f"{coordinator.device_name}-hub-battery-status-{battery_id}"
+            f"{coordinator.mac_id}-hub-battery-status-{battery_id}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_name = (
             "Hub battery status"
@@ -230,9 +233,6 @@ class HikHubBatteryStatus(HikPanelEntity, SensorEntity):
         )
         self._attr_has_entity_name = True
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery_status", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -256,7 +256,10 @@ class HikHubBatteryVoltage(HikPanelEntity, SensorEntity):
         super().__init__(coordinator, entry_id)
         self._battery_id = battery_id
         self._attr_unique_id = (
-            f"{coordinator.device_name}-hub-battery-voltage-{battery_id}"
+            f"{coordinator.mac_id}-hub-battery-voltage-{battery_id}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, coordinator.device_name
         )
         self._attr_name = (
             "Hub battery voltage"
@@ -268,9 +271,6 @@ class HikHubBatteryVoltage(HikPanelEntity, SensorEntity):
         self._attr_native_unit_of_measurement = UnitOfElectricPotential.VOLT
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "hub_battery_voltage", battery_id
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/hikvision_axpro/isapi_bypass.py
+++ b/custom_components/hikvision_axpro/isapi_bypass.py
@@ -1,0 +1,145 @@
+"""ISAPI zone bypass primitives for Hikvision AX Pro panels.
+
+Self-contained wrapper around the ``hikaxpro`` client implementing zone
+bypass/restore with outcome verification, limited retries on transient
+errors and firmware feature detection. It deliberately has no Home
+Assistant imports so it can be proposed upstream to the ``hikaxpro``
+library with minimal rework.
+
+All methods are synchronous (the underlying client is ``requests``
+based); callers are expected to wrap them with an executor.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import hikaxpro
+
+_LOGGER = logging.getLogger(__name__)
+
+BYPASS_ENDPOINT = "/ISAPI/SecurityCP/control/bypass/"
+RECOVER_BYPASS_ENDPOINT = "/ISAPI/SecurityCP/control/Recoverbypass/"
+ZONE_STATUS_ENDPOINT = "/ISAPI/SecurityCP/status/zones"
+
+
+class BypassError(Exception):
+    """Base error for bypass operations."""
+
+
+class BypassUnsupportedError(BypassError):
+    """The panel firmware does not support the bypass endpoint."""
+
+
+class BypassCommandError(BypassError):
+    """The panel rejected the bypass command or it kept failing."""
+
+
+class BypassVerifyError(BypassError):
+    """The panel accepted the command but the re-read state disagrees."""
+
+
+class AxProBypassClient:
+    """Zone bypass primitives with verification and retries."""
+
+    def __init__(
+        self,
+        axpro: hikaxpro.HikAxPro,
+        max_retries: int = 3,
+        backoff_base: float = 0.5,
+    ) -> None:
+        """Wrap an already authenticated HikAxPro client."""
+        self._axpro = axpro
+        self._max_retries = max_retries
+        self._backoff_base = backoff_base
+
+    @staticmethod
+    def detect_support(zone_status: dict[str, Any] | None) -> bool:
+        """Return True if the panel reports zone bypass states.
+
+        A firmware that exposes the ``bypassed`` field in the zone status
+        payload supports the bypass control endpoint. Works on data that
+        is already fetched during setup, so no extra request is needed.
+        """
+        if not zone_status:
+            return False
+        for wrap in zone_status.get("ZoneList") or []:
+            zone = wrap.get("Zone") or {}
+            if zone.get("bypassed") is not None:
+                return True
+        return False
+
+    def fetch_zone_status(self) -> dict[str, Any]:
+        """Fetch a fresh zone status payload from the panel."""
+        response = self._request("GET", ZONE_STATUS_ENDPOINT)
+        return response.json()
+
+    def get_zone_raw(self, zone_id: int) -> dict[str, Any] | None:
+        """Fetch a fresh status dict of a single zone, or None if unknown."""
+        for wrap in self.fetch_zone_status().get("ZoneList") or []:
+            zone = wrap.get("Zone") or {}
+            if zone.get("id") == zone_id:
+                return zone
+        return None
+
+    def bypass(self, zone_id: int) -> None:
+        """Bypass a zone and verify the panel applied it."""
+        self._control(BYPASS_ENDPOINT, zone_id)
+        self._verify(zone_id, expected_bypassed=True)
+
+    def unbypass(self, zone_id: int) -> None:
+        """Restore (unbypass) a zone and verify the panel applied it."""
+        self._control(RECOVER_BYPASS_ENDPOINT, zone_id)
+        self._verify(zone_id, expected_bypassed=False)
+
+    def _control(self, endpoint: str, zone_id: int) -> None:
+        response = self._request("PUT", f"{endpoint}{zone_id}")
+        _LOGGER.debug("Bypass control %s%s -> %s", endpoint, zone_id, response.text)
+
+    def _verify(self, zone_id: int, expected_bypassed: bool) -> None:
+        zone = self.get_zone_raw(zone_id)
+        if zone is None:
+            raise BypassVerifyError(
+                f"Zone {zone_id} not found in status re-read after bypass command"
+            )
+        if zone.get("bypassed") is not expected_bypassed:
+            raise BypassVerifyError(
+                f"Zone {zone_id} bypass state is {zone.get('bypassed')}, "
+                f"expected {expected_bypassed}"
+            )
+
+    def _request(self, method: str, path: str):
+        """Perform a JSON ISAPI request with limited retries on transient errors."""
+        url = self._axpro.build_url(f"http://{self._axpro.host}{path}", True)
+        last_error: Exception | None = None
+        for attempt in range(self._max_retries):
+            if attempt:
+                time.sleep(self._backoff_base * (2 ** (attempt - 1)))
+            try:
+                response = self._axpro.make_request(url, method, None, True)
+            except (ConnectionError, OSError) as err:
+                last_error = err
+                _LOGGER.debug("Transient error on %s %s: %s", method, path, err)
+                continue
+            if response is None:
+                raise BypassCommandError(f"Unsupported HTTP method {method}")
+            if response.status_code == 200:
+                return response
+            if response.status_code in (403, 404):
+                raise BypassUnsupportedError(
+                    f"{method} {path} returned {response.status_code}: {response.text}"
+                )
+            if response.status_code >= 500:
+                last_error = BypassCommandError(
+                    f"{method} {path} returned {response.status_code}: {response.text}"
+                )
+                _LOGGER.debug("Transient HTTP %s on %s %s", response.status_code, method, path)
+                continue
+            raise BypassCommandError(
+                f"{method} {path} returned {response.status_code}: {response.text}"
+            )
+        raise BypassCommandError(
+            f"{method} {path} failed after {self._max_retries} attempts: {last_error}"
+        )

--- a/custom_components/hikvision_axpro/peripheral_entities.py
+++ b/custom_components/hikvision_axpro/peripheral_entities.py
@@ -362,14 +362,14 @@ class HikPeripheralBinary(CoordinatorEntity, BinarySensorEntity):
         self._device_id = device_id
         self._get = get
         self._value_fn = value_fn
-        self._attr_unique_id = f"{coordinator.device_name}-{kind}-{device_id}-{key}"
+        self._attr_unique_id = f"{coordinator.mac_id}-{kind}-{device_id}-{key}"
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id
+        )
         self._attr_name = name
         self._attr_has_entity_name = True
         self._attr_device_class = device_class
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN, coordinator.device_name, kind, device_id, key
-        )
 
     def _current(self):
         return self._get(self.coordinator)
@@ -432,7 +432,10 @@ class HikPeripheralSensor(CoordinatorEntity, SensorEntity):
             SensorDeviceClass.TEMPERATURE,
             SensorDeviceClass.SIGNAL_STRENGTH,
         )
-        self._attr_unique_id = f"{coordinator.device_name}-{kind}-{device_id}-{key}"
+        self._attr_unique_id = f"{coordinator.mac_id}-{kind}-{device_id}-{key}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id
+        )
         self._attr_name = name
         self._attr_has_entity_name = True
         if device_class is not None:
@@ -442,9 +445,6 @@ class HikPeripheralSensor(CoordinatorEntity, SensorEntity):
         if state_class is not None:
             self._attr_state_class = state_class
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, kind, device_id, key
-        )
 
     def _current(self):
         return self._get(self.coordinator)

--- a/custom_components/hikvision_axpro/sensor.py
+++ b/custom_components/hikvision_axpro/sensor.py
@@ -27,9 +27,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import HikAxProDataUpdateCoordinator
+from .entity_id import build_entity_id
 from .const import DATA_COORDINATOR, DOMAIN
 from .hik_device import HikDevice
-from .entity_id import build_entity_id
 from .model import DetectorType, Status, Zone, zone_device_model
 from .host_entities import build_host_sensors
 from .peripheral_entities import (
@@ -137,15 +137,15 @@ class HikTemperature(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-temp-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-temp-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:thermometer"
         # self._attr_name = f"{self.zone.name} Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "temperature", zone.id
-        )
         self._attr_state_class = SensorStateClass.MEASUREMENT
 
     @property
@@ -178,16 +178,16 @@ class HikHumidity(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-humid-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-humid-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:cloud-percent"
         # self._attr_name = f"{self.zone.name} Humidity"
         self._attr_device_class = SensorDeviceClass.HUMIDITY
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "humidity", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -219,16 +219,16 @@ class HikBatteryInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-battery-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-battery-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery"
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "battery", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -264,13 +264,13 @@ class HikChargeStatus(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-charge-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-charge-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:battery-heart-variant"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "charge", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -304,16 +304,16 @@ class HikSignalInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-signal-{zone.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-signal-{zone.id}"
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
+        )
         self._attr_icon = "mdi:signal"
         self._attr_device_class = SensorDeviceClass.SIGNAL_STRENGTH
         self._attr_native_unit_of_measurement = SIGNAL_STRENGTH_DECIBELS_MILLIWATT
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_has_entity_name = True
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "signal", zone.id
-        )
 
     @property
     def name(self) -> str | None:
@@ -345,11 +345,11 @@ class HikStatusInfo(CoordinatorEntity, HikDevice, SensorEntity):
         super().__init__(coordinator)
         self.zone = zone
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-status-{zone.id}"
-        self._attr_has_entity_name = True
+        self._attr_unique_id = f"{self.coordinator.mac_id}-status-{zone.id}"
         self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "status", zone.id
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, zone.name, "z"
         )
+        self._attr_has_entity_name = True
         if (
             self.coordinator.zones
             and self.coordinator.zones[self.zone.id]

--- a/custom_components/hikvision_axpro/services.yaml
+++ b/custom_components/hikvision_axpro/services.yaml
@@ -6,12 +6,40 @@ purge:
   description: Purge old invalid binary sensors registered as sensors
 bypass_zone:
   name: Bypass zone
-  description: Bypass a zone so the panel can arm with it open
+  description: >
+    Bypass one or more zones. The bypass is tracked by the integration and
+    removed automatically when the zone recovers while armed, or on disarm.
+  target:
+    entity:
+      integration: hikvision_axpro
+      domain: binary_sensor
   fields:
     zone_id:
       name: Zone ID
-      description: Zone number from the panel
-      required: true
+      description: Zone number from the panel; use instead of targeting an entity
+      required: false
+      selector:
+        number:
+          min: 0
+          mode: box
+    config_entry_id:
+      name: Config entry ID
+      description: Optional when multiple panels are configured
+      required: false
+      selector:
+        text:
+unbypass_zone:
+  name: Unbypass zone
+  description: Restore (remove the bypass of) one or more zones
+  target:
+    entity:
+      integration: hikvision_axpro
+      domain: binary_sensor
+  fields:
+    zone_id:
+      name: Zone ID
+      description: Zone number from the panel; use instead of targeting an entity
+      required: false
       selector:
         number:
           min: 0
@@ -23,17 +51,37 @@ bypass_zone:
       selector:
         text:
 recover_bypass_zone:
-  name: Recover bypass zone
-  description: Clear bypass on a zone
+  name: Recover bypass zone (deprecated)
+  description: Deprecated alias of unbypass_zone, kept for existing automations
+  target:
+    entity:
+      integration: hikvision_axpro
+      domain: binary_sensor
   fields:
     zone_id:
       name: Zone ID
-      description: Zone number from the panel
-      required: true
+      description: Zone number from the panel; use instead of targeting an entity
+      required: false
       selector:
         number:
           min: 0
           mode: box
+    config_entry_id:
+      name: Config entry ID
+      description: Optional when multiple panels are configured
+      required: false
+      selector:
+        text:
+clear_all_bypasses:
+  name: Clear all bypasses
+  description: >
+    Remove every bypass on the panel, regardless of how it was applied.
+    Targeting an area panel clears only that area's zones.
+  target:
+    entity:
+      integration: hikvision_axpro
+      domain: alarm_control_panel
+  fields:
     config_entry_id:
       name: Config entry ID
       description: Optional when multiple panels are configured

--- a/custom_components/hikvision_axpro/siren_entities.py
+++ b/custom_components/hikvision_axpro/siren_entities.py
@@ -268,7 +268,10 @@ class HikSirenBinary(HikSirenEntity, BinarySensorEntity):
         self._key = key
         self._value_fn = value_fn
         self._attr_unique_id = (
-            f"{coordinator.device_name}-siren-{self.siren_id}-{key}"
+            f"{coordinator.mac_id}-siren-{self.siren_id}-{key}"
+        )
+        self.entity_id = build_entity_id(
+            BINARY_SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, siren.name
         )
         self._attr_name = name
         self._attr_has_entity_name = True
@@ -276,13 +279,6 @@ class HikSirenBinary(HikSirenEntity, BinarySensorEntity):
             self._attr_device_class = device_class
         if diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            BINARY_SENSOR_DOMAIN,
-            coordinator.device_name,
-            "siren",
-            self.siren_id,
-            key,
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -330,7 +326,10 @@ class HikSirenSensor(HikSirenEntity, SensorEntity):
             SensorDeviceClass.SIGNAL_STRENGTH,
         )
         self._attr_unique_id = (
-            f"{coordinator.device_name}-siren-{self.siren_id}-{key}"
+            f"{coordinator.mac_id}-siren-{self.siren_id}-{key}"
+        )
+        self.entity_id = build_entity_id(
+            SENSOR_DOMAIN, self._attr_unique_id, coordinator.mac_id, siren.name
         )
         self._attr_name = name
         self._attr_has_entity_name = True
@@ -342,9 +341,6 @@ class HikSirenSensor(HikSirenEntity, SensorEntity):
             self._attr_state_class = state_class
         if diagnostic:
             self._attr_entity_category = EntityCategory.DIAGNOSTIC
-        self.entity_id = build_entity_id(
-            SENSOR_DOMAIN, coordinator.device_name, "siren", self.siren_id, key
-        )
 
     @callback
     def _handle_coordinator_update(self) -> None:

--- a/custom_components/hikvision_axpro/strings.json
+++ b/custom_components/hikvision_axpro/strings.json
@@ -1,61 +1,127 @@
 {
     "config": {
-      "step": {
-        "user": {
-          "data": {
-            "host": "[%key:common::config_flow::data::host%]",
-            "username": "[%key:common::config_flow::data::username%]",
-            "password": "[%key:common::config_flow::data::password%]",
-            "enabled": "[%key:common::config_flow::data::enabled%]",
-            "code_format": "[%key:common::config_flow::data::code_format%]",
-            "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
-            "code": "[%key:common::config_flow::data::code%]",
-            "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-            "allow_subsystems": "Allow subsystems",
-            "auto_bypass_on_arm": "Auto-bypass open zones before arm",
-            "debug": "Debug logging"
-          }
+        "step": {
+            "user": {
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "enabled": "[%key:common::config_flow::data::enabled%]",
+                    "code_format": "[%key:common::config_flow::data::code_format%]",
+                    "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
+                    "code": "[%key:common::config_flow::data::code%]",
+                    "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+                    "allow_subsystems": "Allow subsystems",
+                    "debug": "Debug logging",
+                    "auto_bypass_modes": "Arming modes with automatic bypass of faulted zones",
+                    "bypass_reenable_debounce": "Seconds a zone must stay healthy before its bypass is removed",
+                    "clear_all_bypasses_on_disarm": "On disarm, remove all bypasses (not only those applied by the integration)"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "invalid_code": "[%key:common::config_flow::error::invalid_code%]",
+            "invalid_code_format": "[%key:common::config_flow::error::invalid_code_format%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
-      },
-      "error": {
-        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-        "invalid_code": "[%key:common::config_flow::error::invalid_code%]",
-        "invalid_code_format": "[%key:common::config_flow::error::invalid_code_format%]",
-        "unknown": "[%key:common::config_flow::error::unknown%]"
-      },
-      "abort": {
-        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-      }
     },
     "options": {
-      "step": {
-        "init": {
-          "data": {
-            "host": "[%key:common::config_flow::data::host%]",
-            "username": "[%key:common::config_flow::data::username%]",
-            "password": "[%key:common::config_flow::data::password%]",
-            "enabled": "[%key:common::config_flow::data::enabled%]",
-            "code_format": "[%key:common::config_flow::data::code_format%]",
-            "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
-            "code": "[%key:common::config_flow::data::code%]",
-            "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
-            "allow_subsystems": "Allow subsystems",
-            "auto_bypass_on_arm": "Auto-bypass open zones before arm",
-            "debug": "Debug logging"
-          }
+        "step": {
+            "init": {
+                "title": "Connection and behaviour",
+                "description": "When a mode has automatic bypass enabled, the next page lets you pick which zones it may bypass.",
+                "data": {
+                    "host": "[%key:common::config_flow::data::host%]",
+                    "username": "[%key:common::config_flow::data::username%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "enabled": "[%key:common::config_flow::data::enabled%]",
+                    "code_format": "[%key:common::config_flow::data::code_format%]",
+                    "use_code_arming": "[%key:common::config_flow::data::use_code_arming%]",
+                    "code": "[%key:common::config_flow::data::code%]",
+                    "scan_interval": "[%key:common::config_flow::data::scan_interval%]",
+                    "allow_subsystems": "Allow subsystems",
+                    "debug": "Debug logging",
+                    "auto_bypass_modes": "Arming modes with automatic bypass of faulted zones",
+                    "bypass_reenable_debounce": "Seconds a zone must stay healthy before its bypass is removed",
+                    "clear_all_bypasses_on_disarm": "On disarm, remove all bypasses (not only those applied by the integration)"
+                }
+            },
+            "bypass_zones": {
+                "title": "Zones that may be bypassed",
+                "description": "Pick, per arming mode, the zones the integration may bypass automatically when they are faulted at arming time. A zone the panel forbids bypassing on arming is ignored.",
+                "data": {
+                    "bypassable_zones_home": "Bypassable on home arming",
+                    "bypassable_zones_away": "Bypassable on away arming",
+                    "bypassable_zones_vacation": "Bypassable on vacation arming"
+                }
+            }
+        },
+        "error": {
+            "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
+            "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "invalid_code": "[%key:common::config_flow::error::invalid_code%]",
+            "invalid_code_format": "[%key:common::config_flow::error::invalid_code_format%]",
+            "unknown": "[%key:common::config_flow::error::unknown%]"
+        },
+        "abort": {
+            "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
         }
-      },
-      "error": {
-        "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
-        "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
-        "invalid_code": "[%key:common::config_flow::error::invalid_code%]",
-        "invalid_code_format": "[%key:common::config_flow::error::invalid_code_format%]",
-        "unknown": "[%key:common::config_flow::error::unknown%]"
-      },
-      "abort": {
-        "already_configured": "[%key:common::config_flow::abort::already_configured_device%]"
-      }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Arming blocked: {reason}. Zones: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Another arming or bypass operation is already in progress"
+        },
+        "arm_refused": {
+            "message": "The panel refused the arm command"
+        },
+        "disarm_refused": {
+            "message": "The panel refused the disarm command"
+        },
+        "bypass_failed": {
+            "message": "Bypass of zone {zone} failed: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Removing the bypass of zone {zone} failed: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "The panel firmware does not support zone bypass"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Zone bypass not supported",
+            "description": "The panel {device} does not report zone bypass states, so the bypass features of this integration are disabled. Everything else keeps working."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Bypass zone",
+            "description": "Bypass one or more zones. The bypass is tracked by the integration and removed automatically when the zone recovers while armed, or on disarm."
+        },
+        "unbypass_zone": {
+            "name": "Unbypass zone",
+            "description": "Restore (remove the bypass of) one or more zones."
+        },
+        "clear_all_bypasses": {
+            "name": "Clear all bypasses",
+            "description": "Remove every bypass on the panel, regardless of how it was applied. Targeting an area panel clears only that area's zones."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Home",
+                "away": "Away",
+                "vacation": "Vacation"
+            }
+        }
     }
-  }
-  
+}

--- a/custom_components/hikvision_axpro/switch.py
+++ b/custom_components/hikvision_axpro/switch.py
@@ -10,8 +10,8 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from homeassistant.helpers import device_registry as dr
 from homeassistant.components.switch import (
-    SwitchEntity,
     DOMAIN as SWITCH_DOMAIN,
+    SwitchEntity,
     SwitchDeviceClass,
 )
 
@@ -79,9 +79,9 @@ class HikRelaySwitch(CoordinatorEntity, SwitchEntity):
         super().__init__(coordinator)
         self.switch = switch
         self._ref_id = entry_id
-        self._attr_unique_id = f"{self.coordinator.device_name}-relay-{switch.id}"
+        self._attr_unique_id = f"{self.coordinator.mac_id}-relay-{switch.id}"
         self.entity_id = build_entity_id(
-            SWITCH_DOMAIN, coordinator.device_name, "relay", switch.id
+            SWITCH_DOMAIN, self._attr_unique_id, coordinator.mac_id, switch.name
         )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(self._ref_id) + "-relay-" + str(switch.id))},
@@ -155,14 +155,14 @@ class HikSirenSwitch(CoordinatorEntity, SwitchEntity):
         self._ref_id = entry_id
         siren = coordinator.sirens.get(siren_id)
         name = (siren.name if siren else None) or f"Siren {siren_id}"
-        self._attr_unique_id = f"{coordinator.device_name}-siren-control-{siren_id}"
+        self._attr_unique_id = f"{coordinator.mac_id}-siren-control-{siren_id}"
+        self.entity_id = build_entity_id(
+            SWITCH_DOMAIN, self._attr_unique_id, coordinator.mac_id, name
+        )
         self._attr_name = "Control"
         self._attr_has_entity_name = True
         self._attr_device_class = SwitchDeviceClass.SWITCH
         self._attr_icon = "mdi:alarm-bell"
-        self.entity_id = build_entity_id(
-            SWITCH_DOMAIN, coordinator.device_name, "siren_control", siren_id
-        )
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, str(entry_id) + "-siren-" + str(siren_id))},
             manufacturer="HikVision",

--- a/custom_components/hikvision_axpro/translations/cs.json
+++ b/custom_components/hikvision_axpro/translations/cs.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Zahrnutí zón jako samostatných oblastí pro zapnutí/vypnutí alarmů",
                     "code": "Kód",
                     "scan_interval": "Aktualizační interval",
-                    "debug": "Zapnout debug výstup"
+                    "debug": "Zapnout debug výstup",
+                    "auto_bypass_modes": "Režimy zastřežení s automatickým přemostěním zón v poruše",
+                    "bypass_reenable_debounce": "Počet sekund, po které musí zóna zůstat v pořádku, než bude přemostění odstraněno",
+                    "clear_all_bypasses_on_disarm": "Při deaktivaci odstranit všechna přemostění (nejen ta provedená integrací)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Akutalizace konfigurace",
+                "title": "Připojení a chování",
+                "description": "Pokud má režim zapnuté automatické přemostění, na další stránce vyberete, které zóny smí přemostit.",
                 "data": {
                     "password": "Heslo",
                     "username": "Uživatelské jméno",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Zahrnutí zón jako samostatných oblastí pro zapnutí/vypnutí alarmů",
                     "code": "Kód",
                     "scan_interval": "Aktualizační interval",
-                    "debug": "Zapnout debug výstup"
+                    "debug": "Zapnout debug výstup",
+                    "auto_bypass_modes": "Režimy zastřežení s automatickým přemostěním zón v poruše",
+                    "bypass_reenable_debounce": "Počet sekund, po které musí zóna zůstat v pořádku, než bude přemostění odstraněno",
+                    "clear_all_bypasses_on_disarm": "Při deaktivaci odstranit všechna přemostění (nejen ta provedená integrací)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zóny, které lze přemostit",
+                "description": "Vyberte pro každý režim zastřežení zóny, které smí integrace automaticky přemostit, pokud jsou při zastřežení v poruše. Zóna, u které centrála zakazuje přemostění při zastřežení, se ignoruje.",
+                "data": {
+                    "bypassable_zones_home": "Přemostitelné při zastřežení doma",
+                    "bypassable_zones_away": "Přemostitelné při zastřežení mimo domov",
+                    "bypassable_zones_vacation": "Přemostitelné při zastřežení dovolená"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Aktivace zablokována: {reason}. Zóny: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Jiná operace aktivace nebo přemostění již probíhá"
+        },
+        "arm_refused": {
+            "message": "Ústředna odmítla příkaz k aktivaci"
+        },
+        "disarm_refused": {
+            "message": "Ústředna odmítla příkaz k deaktivaci"
+        },
+        "bypass_failed": {
+            "message": "Přemostění zóny {zone} se nezdařilo: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Odstranění přemostění zóny {zone} se nezdařilo: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "Firmware ústředny nepodporuje přemostění zón"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Přemostění zón není podporováno",
+            "description": "Ústředna {device} nehlásí stav přemostění zón, funkce přemostění této integrace jsou proto vypnuty. Vše ostatní funguje dál."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Přemostit zónu",
+            "description": "Přemostí jednu nebo více zón. Integrace přemostění sleduje a automaticky je odstraní, jakmile se zóna při aktivovaném systému zotaví, nebo při deaktivaci."
+        },
+        "unbypass_zone": {
+            "name": "Zrušit přemostění zóny",
+            "description": "Obnoví (zruší přemostění) jedné nebo více zón."
+        },
+        "clear_all_bypasses": {
+            "name": "Odstranit všechna přemostění",
+            "description": "Odstraní všechna přemostění na ústředně bez ohledu na to, jak byla provedena. Při cílení na panel oblasti se obnoví pouze zóny dané oblasti."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Doma",
+                "away": "Mimo domov",
+                "vacation": "Dovolená"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/de.json
+++ b/custom_components/hikvision_axpro/translations/de.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Bereiche als separate Zonen zum Aktivieren/Deaktivieren einbeziehen",
                     "code": "Code",
                     "scan_interval": "Scan-Intervall des Systems",
-                    "debug": "Debug-Ausgabe aktivieren"
+                    "debug": "Debug-Ausgabe aktivieren",
+                    "auto_bypass_modes": "Scharfschaltmodi mit automatischem Bypass gestörter Zonen",
+                    "bypass_reenable_debounce": "Sekunden, die eine Zone gesund bleiben muss, bevor die Überbrückung entfernt wird",
+                    "clear_all_bypasses_on_disarm": "Beim Unscharfschalten alle Überbrückungen entfernen (nicht nur die von der Integration gesetzten)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Konfiguration aktualisieren",
+                "title": "Verbindung und Verhalten",
+                "description": "Ist für einen Modus das automatische Überbrücken aktiv, wählen Sie auf der nächsten Seite die betroffenen Zonen.",
                 "data": {
                     "password": "Passwort",
                     "username": "Benutzername",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Bereiche als separate Zonen zum Aktivieren/Deaktivieren einbeziehen",
                     "code": "Code",
                     "scan_interval": "Scan-Intervall des Systems",
-                    "debug": "Debug-Ausgabe aktivieren"
+                    "debug": "Debug-Ausgabe aktivieren",
+                    "auto_bypass_modes": "Scharfschaltmodi mit automatischem Bypass gestörter Zonen",
+                    "bypass_reenable_debounce": "Sekunden, die eine Zone gesund bleiben muss, bevor die Überbrückung entfernt wird",
+                    "clear_all_bypasses_on_disarm": "Beim Unscharfschalten alle Überbrückungen entfernen (nicht nur die von der Integration gesetzten)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zonen, die überbrückt werden dürfen",
+                "description": "Wählen Sie je Scharfschaltmodus die Zonen aus, die die Integration automatisch überbrücken darf, wenn sie beim Scharfschalten gestört sind. Eine Zone, für die die Zentrale das Überbrücken beim Scharfschalten verbietet, wird ignoriert.",
+                "data": {
+                    "bypassable_zones_home": "Überbrückbar beim Scharfschalten (anwesend)",
+                    "bypassable_zones_away": "Überbrückbar beim Scharfschalten (abwesend)",
+                    "bypassable_zones_vacation": "Überbrückbar beim Scharfschalten (Urlaub)"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Scharfschalten blockiert: {reason}. Zonen: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Eine andere Scharfschalt- oder Überbrückungsaktion läuft bereits"
+        },
+        "arm_refused": {
+            "message": "Die Zentrale hat den Scharfschaltbefehl abgelehnt"
+        },
+        "disarm_refused": {
+            "message": "Die Zentrale hat den Unscharfschaltbefehl abgelehnt"
+        },
+        "bypass_failed": {
+            "message": "Überbrückung von Zone {zone} fehlgeschlagen: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Entfernen der Überbrückung von Zone {zone} fehlgeschlagen: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "Die Firmware der Zentrale unterstützt keine Zonenüberbrückung"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Zonenüberbrückung nicht unterstützt",
+            "description": "Die Zentrale {device} meldet keine Überbrückungszustände der Zonen, daher sind die Überbrückungsfunktionen dieser Integration deaktiviert. Alles andere funktioniert weiterhin."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Zone überbrücken",
+            "description": "Überbrückt eine oder mehrere Zonen. Die Überbrückung wird von der Integration verfolgt und automatisch entfernt, wenn sich die Zone im scharfen Zustand erholt oder beim Unscharfschalten."
+        },
+        "unbypass_zone": {
+            "name": "Zonenüberbrückung aufheben",
+            "description": "Stellt eine oder mehrere Zonen wieder her (entfernt die Überbrückung)."
+        },
+        "clear_all_bypasses": {
+            "name": "Alle Überbrückungen entfernen",
+            "description": "Entfernt jede Überbrückung an der Zentrale, unabhängig davon, wie sie gesetzt wurde. Bei Auswahl eines Bereichspanels werden nur die Zonen dieses Bereichs wiederhergestellt."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Zu Hause",
+                "away": "Abwesend",
+                "vacation": "Urlaub"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/en.json
+++ b/custom_components/hikvision_axpro/translations/en.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Include areas as separate zones for arm/disarm",
                     "code": "Code",
                     "scan_interval": "Pull interval from system",
-                    "debug": "Enable debug output"
+                    "debug": "Enable debug output",
+                    "auto_bypass_modes": "Arming modes with automatic bypass of faulted zones",
+                    "bypass_reenable_debounce": "Seconds a zone must stay healthy before its bypass is removed",
+                    "clear_all_bypasses_on_disarm": "On disarm, remove all bypasses (not only those applied by the integration)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Update configuration",
+                "title": "Connection and behaviour",
+                "description": "When a mode has automatic bypass enabled, the next page lets you pick which zones it may bypass.",
                 "data": {
                     "password": "Password",
                     "username": "Username",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Include areas as separate zones for arm/disarm",
                     "code": "Code",
                     "scan_interval": "Pull interval from system",
-                    "debug": "Enable debug output"
+                    "debug": "Enable debug output",
+                    "auto_bypass_modes": "Arming modes with automatic bypass of faulted zones",
+                    "bypass_reenable_debounce": "Seconds a zone must stay healthy before its bypass is removed",
+                    "clear_all_bypasses_on_disarm": "On disarm, remove all bypasses (not only those applied by the integration)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zones that may be bypassed",
+                "description": "Pick, per arming mode, the zones the integration may bypass automatically when they are faulted at arming time. A zone the panel forbids bypassing on arming is ignored.",
+                "data": {
+                    "bypassable_zones_home": "Bypassable on home arming",
+                    "bypassable_zones_away": "Bypassable on away arming",
+                    "bypassable_zones_vacation": "Bypassable on vacation arming"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Arming blocked: {reason}. Zones: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Another arming or bypass operation is already in progress"
+        },
+        "arm_refused": {
+            "message": "The panel refused the arm command"
+        },
+        "disarm_refused": {
+            "message": "The panel refused the disarm command"
+        },
+        "bypass_failed": {
+            "message": "Bypass of zone {zone} failed: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Removing the bypass of zone {zone} failed: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "The panel firmware does not support zone bypass"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Zone bypass not supported",
+            "description": "The panel {device} does not report zone bypass states, so the bypass features of this integration are disabled. Everything else keeps working."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Bypass zone",
+            "description": "Bypass one or more zones. The bypass is tracked by the integration and removed automatically when the zone recovers while armed, or on disarm."
+        },
+        "unbypass_zone": {
+            "name": "Unbypass zone",
+            "description": "Restore (remove the bypass of) one or more zones."
+        },
+        "clear_all_bypasses": {
+            "name": "Clear all bypasses",
+            "description": "Remove every bypass on the panel, regardless of how it was applied. Targeting an area panel clears only that area's zones."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Home",
+                "away": "Away",
+                "vacation": "Vacation"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/es.json
+++ b/custom_components/hikvision_axpro/translations/es.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de escaneo del sistema",
-                    "debug": "Habilitar salida de depuración"
+                    "debug": "Habilitar salida de depuración",
+                    "auto_bypass_modes": "Modos de armado con anulación automática de zonas con fallo",
+                    "bypass_reenable_debounce": "Segundos que una zona debe permanecer sana antes de retirar la anulación",
+                    "clear_all_bypasses_on_disarm": "Al desarmar, retirar todas las anulaciones (no solo las aplicadas por la integración)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Actualizar configuración",
+                "title": "Conexión y comportamiento",
+                "description": "Cuando un modo tiene la anulación automática activada, en la página siguiente eliges qué zonas puede anular.",
                 "data": {
                     "password": "Contraseña",
                     "username": "Usuario",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de escaneo del sistema",
-                    "debug": "Habilitar salida de depuración"
+                    "debug": "Habilitar salida de depuración",
+                    "auto_bypass_modes": "Modos de armado con anulación automática de zonas con fallo",
+                    "bypass_reenable_debounce": "Segundos que una zona debe permanecer sana antes de retirar la anulación",
+                    "clear_all_bypasses_on_disarm": "Al desarmar, retirar todas las anulaciones (no solo las aplicadas por la integración)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zonas que se pueden anular",
+                "description": "Elija, por cada modo de armado, las zonas que la integración puede anular automáticamente cuando están en avería al armar. Una zona para la que el panel prohíbe la anulación al armar se ignora.",
+                "data": {
+                    "bypassable_zones_home": "Anulable al armar en casa",
+                    "bypassable_zones_away": "Anulable al armar fuera",
+                    "bypassable_zones_vacation": "Anulable al armar en vacaciones"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Armado bloqueado: {reason}. Zonas: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Ya hay otra operación de armado o anulación en curso"
+        },
+        "arm_refused": {
+            "message": "El panel rechazó la orden de armado"
+        },
+        "disarm_refused": {
+            "message": "El panel rechazó la orden de desarmado"
+        },
+        "bypass_failed": {
+            "message": "Falló la anulación de la zona {zone}: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Falló la retirada de la anulación de la zona {zone}: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "El firmware del panel no admite la anulación de zonas"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Anulación de zonas no admitida",
+            "description": "El panel {device} no informa del estado de anulación de las zonas, por lo que las funciones de anulación de esta integración están desactivadas. Todo lo demás sigue funcionando."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Anular zona",
+            "description": "Anula una o varias zonas. La integración registra la anulación y la retira automáticamente cuando la zona se recupera estando armado, o al desarmar."
+        },
+        "unbypass_zone": {
+            "name": "Restaurar zona",
+            "description": "Restaura (retira la anulación de) una o varias zonas."
+        },
+        "clear_all_bypasses": {
+            "name": "Retirar todas las anulaciones",
+            "description": "Retira todas las anulaciones del panel, independientemente de cómo se aplicaran. Si se selecciona el panel de un área, solo se restauran las zonas de esa área."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "En casa",
+                "away": "Ausente",
+                "vacation": "Vacaciones"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/fr.json
+++ b/custom_components/hikvision_axpro/translations/fr.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Inclure des zones comme des zones distinctes pour armer/désarmer",
                     "code": "Code",
                     "scan_interval": "Intervalle de balayage du système",
-                    "debug": "Activer la sortie de débogage"
+                    "debug": "Activer la sortie de débogage",
+                    "auto_bypass_modes": "Modes d'armement avec exclusion automatique des zones en défaut",
+                    "bypass_reenable_debounce": "Secondes pendant lesquelles une zone doit rester saine avant le retrait de l'exclusion",
+                    "clear_all_bypasses_on_disarm": "Au désarmement, retirer toutes les exclusions (pas seulement celles appliquées par l'intégration)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Mettre à jour la configuration",
+                "title": "Connexion et comportement",
+                "description": "Lorsqu'un mode a la mise hors service automatique activée, la page suivante permet de choisir les zones concernées.",
                 "data": {
                     "password": "Mot de passe",
                     "username": "Nom d'utilisateur",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Inclure des zones comme des zones distinctes pour armer/désarmer",
                     "code": "Code",
                     "scan_interval": "Intervalle de balayage du système",
-                    "debug": "Activer la sortie de débogage"
+                    "debug": "Activer la sortie de débogage",
+                    "auto_bypass_modes": "Modes d'armement avec exclusion automatique des zones en défaut",
+                    "bypass_reenable_debounce": "Secondes pendant lesquelles une zone doit rester saine avant le retrait de l'exclusion",
+                    "clear_all_bypasses_on_disarm": "Au désarmement, retirer toutes les exclusions (pas seulement celles appliquées par l'intégration)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zones pouvant être mises hors service",
+                "description": "Choisissez, pour chaque mode d'armement, les zones que l'intégration peut mettre hors service automatiquement lorsqu'elles sont en défaut à l'armement. Une zone dont la centrale interdit la mise hors service à l'armement est ignorée.",
+                "data": {
+                    "bypassable_zones_home": "Isolable à l'armement présence",
+                    "bypassable_zones_away": "Isolable à l'armement absence",
+                    "bypassable_zones_vacation": "Isolable à l'armement vacances"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Armement bloqué : {reason}. Zones : {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Une autre opération d'armement ou d'exclusion est déjà en cours"
+        },
+        "arm_refused": {
+            "message": "La centrale a refusé la commande d'armement"
+        },
+        "disarm_refused": {
+            "message": "La centrale a refusé la commande de désarmement"
+        },
+        "bypass_failed": {
+            "message": "Échec de l'exclusion de la zone {zone} : {error}"
+        },
+        "unbypass_failed": {
+            "message": "Échec du retrait de l'exclusion de la zone {zone} : {error}"
+        },
+        "bypass_unsupported": {
+            "message": "Le micrologiciel de la centrale ne prend pas en charge l'exclusion de zones"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Exclusion de zones non prise en charge",
+            "description": "La centrale {device} ne signale pas l'état d'exclusion des zones ; les fonctions d'exclusion de cette intégration sont donc désactivées. Tout le reste continue de fonctionner."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Exclure une zone",
+            "description": "Exclut une ou plusieurs zones. L'exclusion est suivie par l'intégration et retirée automatiquement lorsque la zone redevient saine pendant l'armement, ou au désarmement."
+        },
+        "unbypass_zone": {
+            "name": "Réintégrer une zone",
+            "description": "Réintègre (retire l'exclusion d')une ou plusieurs zones."
+        },
+        "clear_all_bypasses": {
+            "name": "Retirer toutes les exclusions",
+            "description": "Retire toutes les exclusions de la centrale, quelle que soit leur origine. Cibler le panneau d'une zone ne réintègre que les zones de cette partition."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "À domicile",
+                "away": "Absent",
+                "vacation": "Vacances"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/it.json
+++ b/custom_components/hikvision_axpro/translations/it.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Includi aree come zone separate per armare/disarmare",
                     "code": "Codice",
                     "scan_interval": "Intervallo di scansione del sistema",
-                    "debug": "Abilita l'output di debug"
+                    "debug": "Abilita l'output di debug",
+                    "auto_bypass_modes": "Modalità di inserimento con bypass automatico delle zone in anomalia",
+                    "bypass_reenable_debounce": "Secondi per cui una zona deve rimanere sana prima che il bypass venga rimosso",
+                    "clear_all_bypasses_on_disarm": "Al disinserimento, rimuovi tutti i bypass (non solo quelli applicati dall'integrazione)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Aggiorna configurazione",
+                "title": "Connessione e comportamento",
+                "description": "Quando una modalità ha il bypass automatico attivo, nella pagina successiva puoi scegliere quali zone può bypassare.",
                 "data": {
                     "password": "Password",
                     "username": "Nome utente",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Includi aree come zone separate per armare/disarmare",
                     "code": "Codice",
                     "scan_interval": "Intervallo di scansione del sistema",
-                    "debug": "Abilita l'output di debug"
+                    "debug": "Abilita l'output di debug",
+                    "auto_bypass_modes": "Modalità di inserimento con bypass automatico delle zone in anomalia",
+                    "bypass_reenable_debounce": "Secondi per cui una zona deve rimanere sana prima che il bypass venga rimosso",
+                    "clear_all_bypasses_on_disarm": "Al disinserimento, rimuovi tutti i bypass (non solo quelli applicati dall'integrazione)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zone che possono essere bypassate",
+                "description": "Scegli, per ogni modalità di inserimento, le zone che l'integrazione può bypassare automaticamente quando sono in anomalia al momento dell'inserimento. Una zona per cui la centrale vieta il bypass all'inserimento viene ignorata.",
+                "data": {
+                    "bypassable_zones_home": "Bypassabile con inserimento in casa",
+                    "bypassable_zones_away": "Bypassabile con inserimento fuori casa",
+                    "bypassable_zones_vacation": "Bypassabile con inserimento vacanza"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Inserimento bloccato: {reason}. Zone: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Un'altra operazione di inserimento o bypass è già in corso"
+        },
+        "arm_refused": {
+            "message": "La centrale ha rifiutato il comando di inserimento"
+        },
+        "disarm_refused": {
+            "message": "La centrale ha rifiutato il comando di disinserimento"
+        },
+        "bypass_failed": {
+            "message": "Bypass della zona {zone} non riuscito: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Rimozione del bypass della zona {zone} non riuscita: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "Il firmware della centrale non supporta il bypass delle zone"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Bypass delle zone non supportato",
+            "description": "La centrale {device} non riporta lo stato di bypass delle zone, quindi le funzionalità di bypass di questa integrazione sono disabilitate. Tutto il resto continua a funzionare."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Bypassa zona",
+            "description": "Bypassa una o più zone. Il bypass è tracciato dall'integrazione e rimosso automaticamente quando la zona torna sana a impianto inserito, o al disinserimento."
+        },
+        "unbypass_zone": {
+            "name": "Rimuovi bypass zona",
+            "description": "Ripristina (rimuove il bypass di) una o più zone."
+        },
+        "clear_all_bypasses": {
+            "name": "Rimuovi tutti i bypass",
+            "description": "Rimuove ogni bypass sulla centrale, indipendentemente da come è stato applicato. Selezionando il pannello di un'area vengono ripristinate solo le zone di quell'area."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "In casa",
+                "away": "Fuori casa",
+                "vacation": "Vacanza"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/pt-BR.json
+++ b/custom_components/hikvision_axpro/translations/pt-BR.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de extração do sistema",
-                    "debug": "Habilitar saída de depuração"
+                    "debug": "Habilitar saída de depuração",
+                    "auto_bypass_modes": "Modos de armar com bypass automático de zonas com falha",
+                    "bypass_reenable_debounce": "Segundos que uma zona deve permanecer saudável antes de a anulação ser removida",
+                    "clear_all_bypasses_on_disarm": "Ao desarmar, remover todas as anulações (não apenas as aplicadas pela integração)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Atualizar configuração",
+                "title": "Conexão e comportamento",
+                "description": "Quando um modo tem a inibição automática ativa, a página seguinte permite escolher as zonas abrangidas.",
                 "data": {
                     "password": "Palava passe",
                     "username": "Usuário",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de extração do sistema",
-                    "debug": "Habilitar saída de depuração"
+                    "debug": "Habilitar saída de depuração",
+                    "auto_bypass_modes": "Modos de armar com bypass automático de zonas com falha",
+                    "bypass_reenable_debounce": "Segundos que uma zona deve permanecer saudável antes de a anulação ser removida",
+                    "clear_all_bypasses_on_disarm": "Ao desarmar, remover todas as anulações (não apenas as aplicadas pela integração)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zonas que podem ser inibidas",
+                "description": "Escolha, para cada modo de armação, as zonas que a integração pode inibir automaticamente quando estiverem em falha na armação. Uma zona cuja central proíbe a inibição na armação é ignorada.",
+                "data": {
+                    "bypassable_zones_home": "Inibível ao armar em casa",
+                    "bypassable_zones_away": "Inibível ao armar ausente",
+                    "bypassable_zones_vacation": "Inibível ao armar em férias"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Armar bloqueado: {reason}. Zonas: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Outra operação de armar ou anulação já está em andamento"
+        },
+        "arm_refused": {
+            "message": "O painel recusou o comando de armar"
+        },
+        "disarm_refused": {
+            "message": "O painel recusou o comando de desarmar"
+        },
+        "bypass_failed": {
+            "message": "A anulação da zona {zone} falhou: {error}"
+        },
+        "unbypass_failed": {
+            "message": "A remoção da anulação da zona {zone} falhou: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "O firmware do painel não suporta anulação de zonas"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Anulação de zonas não suportada",
+            "description": "O painel {device} não reporta o estado de anulação das zonas, então os recursos de anulação desta integração estão desativados. Todo o resto continua funcionando."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Anular zona",
+            "description": "Anula uma ou mais zonas. A anulação é registrada pela integração e removida automaticamente quando a zona se recupera com o sistema armado, ou ao desarmar."
+        },
+        "unbypass_zone": {
+            "name": "Restaurar zona",
+            "description": "Restaura (remove a anulação de) uma ou mais zonas."
+        },
+        "clear_all_bypasses": {
+            "name": "Remover todas as anulações",
+            "description": "Remove todas as anulações do painel, independentemente de como foram aplicadas. Ao selecionar o painel de uma área, apenas as zonas dessa área são restauradas."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Em casa",
+                "away": "Ausente",
+                "vacation": "Férias"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/pt.json
+++ b/custom_components/hikvision_axpro/translations/pt.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de extração do sistema",
-                    "debug": "Habilitar saída de depuração"
+                    "debug": "Habilitar saída de depuração",
+                    "auto_bypass_modes": "Modos de armar com bypass automático de zonas com falha",
+                    "bypass_reenable_debounce": "Segundos que uma zona deve permanecer saudável antes de a anulação ser removida",
+                    "clear_all_bypasses_on_disarm": "Ao desarmar, remover todas as anulações (não apenas as aplicadas pela integração)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Atualizar configuração",
+                "title": "Ligação e comportamento",
+                "description": "Quando um modo tem a inibição automática ativa, a página seguinte permite escolher as zonas abrangidas.",
                 "data": {
                     "password": "Palava passe",
                     "username": "Usuário",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Incluir áreas como zonas separadas para armar/desarmar",
                     "code": "Código",
                     "scan_interval": "Intervalo de extração do sistema",
-                    "debug": "Habilitar saída de depuração"
+                    "debug": "Habilitar saída de depuração",
+                    "auto_bypass_modes": "Modos de armar com bypass automático de zonas com falha",
+                    "bypass_reenable_debounce": "Segundos que uma zona deve permanecer saudável antes de a anulação ser removida",
+                    "clear_all_bypasses_on_disarm": "Ao desarmar, remover todas as anulações (não apenas as aplicadas pela integração)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Zonas que podem ser inibidas",
+                "description": "Escolha, para cada modo de armação, as zonas que a integração pode inibir automaticamente quando estiverem em falha na armação. Uma zona cuja central proíbe a inibição na armação é ignorada.",
+                "data": {
+                    "bypassable_zones_home": "Inibível ao armar em casa",
+                    "bypassable_zones_away": "Inibível ao armar ausente",
+                    "bypassable_zones_vacation": "Inibível ao armar em férias"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Armar bloqueado: {reason}. Zonas: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Já está em curso outra operação de armar ou anulação"
+        },
+        "arm_refused": {
+            "message": "O painel recusou o comando de armar"
+        },
+        "disarm_refused": {
+            "message": "O painel recusou o comando de desarmar"
+        },
+        "bypass_failed": {
+            "message": "A anulação da zona {zone} falhou: {error}"
+        },
+        "unbypass_failed": {
+            "message": "A remoção da anulação da zona {zone} falhou: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "O firmware do painel não suporta a anulação de zonas"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Anulação de zonas não suportada",
+            "description": "O painel {device} não reporta o estado de anulação das zonas, pelo que as funções de anulação desta integração estão desativadas. Tudo o resto continua a funcionar."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Anular zona",
+            "description": "Anula uma ou mais zonas. A anulação é registada pela integração e removida automaticamente quando a zona recupera com o sistema armado, ou ao desarmar."
+        },
+        "unbypass_zone": {
+            "name": "Restaurar zona",
+            "description": "Restaura (remove a anulação de) uma ou mais zonas."
+        },
+        "clear_all_bypasses": {
+            "name": "Remover todas as anulações",
+            "description": "Remove todas as anulações do painel, independentemente de como foram aplicadas. Ao selecionar o painel de uma área, apenas as zonas dessa área são restauradas."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Em casa",
+                "away": "Ausente",
+                "vacation": "Férias"
             }
         }
     }

--- a/custom_components/hikvision_axpro/translations/sl.json
+++ b/custom_components/hikvision_axpro/translations/sl.json
@@ -23,7 +23,10 @@
                     "allow_subsystems": "Vključite območja kot ločena območja za vklop/izklop alarmiranja",
                     "code": "Koda",
                     "scan_interval": "Interval preverjanja sistema",
-                    "debug": "Enable debug output"
+                    "debug": "Enable debug output",
+                    "auto_bypass_modes": "Načini vklopa s samodejnim premoščanjem okvarjenih con",
+                    "bypass_reenable_debounce": "Koliko sekund mora biti cona zdrava, preden se premostitev odstrani",
+                    "clear_all_bypasses_on_disarm": "Ob izklopu odstrani vse premostitve (ne le tistih, ki jih je uporabila integracija)"
                 }
             }
         }
@@ -31,7 +34,8 @@
     "options": {
         "step": {
             "init": {
-                "title": "Posodobi konfiguracijo",
+                "title": "Povezava in obnašanje",
+                "description": "Kadar ima način vklopljeno samodejno premostitev, na naslednji strani izberete, katere cone sme premostiti.",
                 "data": {
                     "password": "Geslo",
                     "username": "Uporabniško ime",
@@ -41,8 +45,72 @@
                     "allow_subsystems": "Vključite območja kot ločena območja za vklop/izklop alarmiranja",
                     "code": "Koda",
                     "scan_interval": "Interval preverjanja sistema",
-                    "debug": "Enable debug output"
+                    "debug": "Enable debug output",
+                    "auto_bypass_modes": "Načini vklopa s samodejnim premoščanjem okvarjenih con",
+                    "bypass_reenable_debounce": "Koliko sekund mora biti cona zdrava, preden se premostitev odstrani",
+                    "clear_all_bypasses_on_disarm": "Ob izklopu odstrani vse premostitve (ne le tistih, ki jih je uporabila integracija)"
                 }
+            },
+            "bypass_zones": {
+                "title": "Cone, ki jih je dovoljeno premostiti",
+                "description": "Za vsak način vklopa izberite cone, ki jih sme integracija samodejno premostiti, kadar so ob vklopu v napaki. Cona, pri kateri centrala premostitev ob vklopu prepoveduje, je prezrta.",
+                "data": {
+                    "bypassable_zones_home": "Premostljiva ob vklopu doma",
+                    "bypassable_zones_away": "Premostljiva ob vklopu odsotnost",
+                    "bypassable_zones_vacation": "Premostljiva ob vklopu počitnice"
+                }
+            }
+        }
+    },
+    "exceptions": {
+        "arming_blocked": {
+            "message": "Vklop blokiran: {reason}. Cone: {zones}"
+        },
+        "arming_in_progress": {
+            "message": "Druga operacija vklopa ali premostitve že poteka"
+        },
+        "arm_refused": {
+            "message": "Centrala je zavrnila ukaz za vklop"
+        },
+        "disarm_refused": {
+            "message": "Centrala je zavrnila ukaz za izklop"
+        },
+        "bypass_failed": {
+            "message": "Premostitev cone {zone} ni uspela: {error}"
+        },
+        "unbypass_failed": {
+            "message": "Odstranitev premostitve cone {zone} ni uspela: {error}"
+        },
+        "bypass_unsupported": {
+            "message": "Strojna programska oprema centrale ne podpira premostitve con"
+        }
+    },
+    "issues": {
+        "bypass_unsupported": {
+            "title": "Premostitev con ni podprta",
+            "description": "Centrala {device} ne poroča o stanju premostitve con, zato so funkcije premostitve te integracije onemogočene. Vse ostalo deluje naprej."
+        }
+    },
+    "services": {
+        "bypass_zone": {
+            "name": "Premosti cono",
+            "description": "Premosti eno ali več con. Integracija premostitev spremlja in jo samodejno odstrani, ko si cona ob vklopljenem sistemu opomore, ali ob izklopu."
+        },
+        "unbypass_zone": {
+            "name": "Odstrani premostitev cone",
+            "description": "Obnovi (odstrani premostitev) eno ali več con."
+        },
+        "clear_all_bypasses": {
+            "name": "Odstrani vse premostitve",
+            "description": "Odstrani vse premostitve na centrali, ne glede na to, kako so bile uporabljene. Pri ciljanju na panel območja se obnovijo samo cone tega območja."
+        }
+    },
+    "selector": {
+        "auto_bypass_modes": {
+            "options": {
+                "home": "Doma",
+                "away": "Odsotnost",
+                "vacation": "Počitnice"
             }
         }
     }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "-ra -q -p no:pytest-sqlalchemy"
+asyncio_mode = "auto"
 testpaths = [
     "tests",
 ]

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -2,4 +2,4 @@ hikaxpro==2.3.0
 homeassistant
 xmltodict
 pytest
-
+pytest-homeassistant-custom-component

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,9 +19,13 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.hikvision_axpro.const import (
     ALLOW_SUBSYSTEMS,
+    ARM_MODES,
+    CONF_AUTO_BYPASS_MODES,
+    DATA_BYPASS_MANAGER,
     DATA_COORDINATOR,
     DOMAIN,
     USE_CODE_ARMING,
+    conf_bypassable_zones,
 )
 
 pytest_plugins = "pytest_homeassistant_custom_component"
@@ -97,7 +101,7 @@ class MockAxPro:
     def __init__(self, zones: list[dict] | None = None, subsystems=None):
         self.zones: dict[int, dict] = {z["id"]: z for z in (zones or [])}
         # Optional per-zone configuration payloads (ZonesConfig endpoint),
-        # e.g. {"id": 1, "zoneName": "Front door"}
+        # e.g. {"id": 1, "zoneName": "Front door", "armNoBypassEnabled": True}
         self.zone_configs: list[dict] = []
         self.subsystems = subsystems or [
             {
@@ -109,8 +113,12 @@ class MockAxPro:
                 "delayTime": 0,
             }
         ]
+        self.fail_bypass_zones: set[int] = set()
+        self.fail_unbypass_zones: set[int] = set()
         self.refuse_arm = False
         self.zone_status_fail = False
+        self.bypass_calls: list[int] = []
+        self.unbypass_calls: list[int] = []
         self.arm_calls: list[tuple[str, int | None]] = []
 
     # --- helpers for tests -------------------------------------------------
@@ -178,6 +186,20 @@ class MockAxPro:
             if self.zone_status_fail:
                 raise ConnectionError("zone status unavailable")
             return MockResponse(json_data=self.zone_status())
+        if "control/bypass/" in endpoint:
+            zone_id = int(endpoint.split("control/bypass/")[1].split("?")[0])
+            self.bypass_calls.append(zone_id)
+            if zone_id in self.fail_bypass_zones:
+                return MockResponse(status_code=400, text="bypass refused")
+            self.zones[zone_id]["bypassed"] = True
+            return MockResponse(json_data={"statusCode": 1})
+        if "control/Recoverbypass/" in endpoint:
+            zone_id = int(endpoint.split("control/Recoverbypass/")[1].split("?")[0])
+            self.unbypass_calls.append(zone_id)
+            if zone_id in self.fail_unbypass_zones:
+                return MockResponse(status_code=400, text="unbypass refused")
+            self.zones[zone_id]["bypassed"] = False
+            return MockResponse(json_data={"statusCode": 1})
         if "deviceInfo" in endpoint:
             return MockResponse(text=DEVICE_INFO_XML)
         if "Configuration/zones" in endpoint:
@@ -193,7 +215,7 @@ class MockAxPro:
 
 @pytest.fixture
 def panel():
-    """A default panel: door zone 1 + PIR zone 2."""
+    """A default panel: door zone 1 (bypassable candidate) + PIR zone 2."""
     mock = MockAxPro(
         zones=[
             zone_payload(1, name="Front door", magnet_open=False),
@@ -205,8 +227,11 @@ def panel():
 
 
 def make_entry(
-    hass, entry_id: str = "test-entry", **overrides
-) -> MockConfigEntry:
+    hass,
+    bypassable: dict[str, list[int]] | None = None,
+    entry_id: str = "test-entry",
+    **overrides,
+):
     """Create and register a config entry with sane defaults."""
     data = {
         CONF_HOST: "1.2.3.4",
@@ -218,16 +243,22 @@ def make_entry(
         USE_CODE_ARMING: False,
         CONF_SCAN_INTERVAL: 30,
         ALLOW_SUBSYSTEMS: False,
+        CONF_AUTO_BYPASS_MODES: list(ARM_MODES),
     }
+    for mode, zone_ids in (bypassable or {}).items():
+        data[conf_bypassable_zones(mode)] = list(zone_ids)
     data.update(overrides)
+    # An override of None means "this key was never set", which is how a
+    # config entry from an older release looks.
+    data = {key: value for key, value in data.items() if value is not None}
     entry = MockConfigEntry(domain=DOMAIN, data=data, entry_id=entry_id)
     entry.add_to_hass(hass)
     return entry
 
 
-async def setup_entry(hass, **overrides) -> MockConfigEntry:
+async def setup_entry(hass, bypassable=None, **overrides) -> MockConfigEntry:
     """Set up the integration and wait for it to settle."""
-    entry = make_entry(hass, **overrides)
+    entry = make_entry(hass, bypassable=bypassable, **overrides)
     assert await hass.config_entries.async_setup(entry.entry_id)
     await hass.async_block_till_done()
     return entry
@@ -235,3 +266,7 @@ async def setup_entry(hass, **overrides) -> MockConfigEntry:
 
 def get_coordinator(hass, entry):
     return hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]
+
+
+def get_manager(hass, entry):
+    return hass.data[DOMAIN][entry.entry_id][DATA_BYPASS_MANAGER]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,237 @@
+"""Shared fixtures: a mock AX Pro panel with in-memory state."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.const import (
+    ATTR_CODE_FORMAT,
+    CONF_CODE,
+    CONF_ENABLED,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.hikvision_axpro.const import (
+    ALLOW_SUBSYSTEMS,
+    DATA_COORDINATOR,
+    DOMAIN,
+    USE_CODE_ARMING,
+)
+
+pytest_plugins = "pytest_homeassistant_custom_component"
+
+DEVICE_INFO_XML = (
+    '<DeviceInfo xmlns="http://www.hikvision.com/ver20/XMLSchema">'
+    "<deviceName>axpro</deviceName><model>AX PRO</model></DeviceInfo>"
+)
+
+
+@pytest.fixture
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Allow loading the custom component.
+
+    Applied via ``pytestmark`` in the integration-level test modules so
+    that the pure-function tests do not pull in the ``hass`` fixture.
+    """
+    yield
+
+
+def zone_payload(
+    zone_id: int = 1,
+    name: str | None = None,
+    status: str = "online",
+    bypassed: bool = False,
+    armed: bool = False,
+    alarm: bool = False,
+    tamper: bool = False,
+    sub_system_no: int = 1,
+    zone_type: str = "Instant",
+    magnet_open: bool | None = None,
+    charge: str | None = None,
+    stay_away: bool | None = None,
+) -> dict:
+    """Build a raw zone status dict as the panel returns it."""
+    payload = {
+        "id": zone_id,
+        "name": name or f"Zone {zone_id}",
+        "status": status,
+        "tamperEvident": tamper,
+        "bypassed": bypassed,
+        "armed": armed,
+        "alarm": alarm,
+        "subSystemNo": sub_system_no,
+        "zoneType": zone_type,
+    }
+    if magnet_open is not None:
+        payload["magnetOpenStatus"] = magnet_open
+    if charge is not None:
+        payload["charge"] = charge
+    if stay_away is not None:
+        payload["stayAway"] = stay_away
+    return payload
+
+
+class MockResponse:
+    """Minimal requests.Response stand-in."""
+
+    def __init__(self, status_code: int = 200, text: str = "", json_data=None):
+        self.status_code = status_code
+        self.text = text or (str(json_data) if json_data is not None else "")
+        self._json = json_data
+
+    def json(self):
+        return self._json
+
+
+class MockAxPro:
+    """In-memory AX Pro panel implementing the hikaxpro client API."""
+
+    host = "1.2.3.4"
+
+    def __init__(self, zones: list[dict] | None = None, subsystems=None):
+        self.zones: dict[int, dict] = {z["id"]: z for z in (zones or [])}
+        # Optional per-zone configuration payloads (ZonesConfig endpoint),
+        # e.g. {"id": 1, "zoneName": "Front door"}
+        self.zone_configs: list[dict] = []
+        self.subsystems = subsystems or [
+            {
+                "id": 1,
+                "arming": "disarm",
+                "alarm": False,
+                "enabled": True,
+                "name": "Area 1",
+                "delayTime": 0,
+            }
+        ]
+        self.refuse_arm = False
+        self.zone_status_fail = False
+        self.arm_calls: list[tuple[str, int | None]] = []
+
+    # --- helpers for tests -------------------------------------------------
+    def set_zone(self, zone_id: int, **fields) -> None:
+        self.zones[zone_id].update(fields)
+
+    def area(self, sub_id: int = 1) -> dict:
+        return next(s for s in self.subsystems if s["id"] == sub_id)
+
+    # --- hikaxpro client API ------------------------------------------------
+    def get_interface_mac_address(self, interface_id):
+        return "00:11:22:33:44:55"
+
+    def set_logging_level(self, level):
+        pass
+
+    def connect(self):
+        return True
+
+    @staticmethod
+    def build_url(endpoint, is_json=False):
+        prefix = "&" if "?" in endpoint else "?"
+        return f"{endpoint}{prefix}format=json" if is_json else endpoint
+
+    def subsystem_status(self):
+        return {"SubSysList": [{"SubSys": dict(sub)} for sub in self.subsystems]}
+
+    def zone_status(self):
+        if self.zone_status_fail:
+            raise ConnectionError("zone status unavailable")
+        return {"ZoneList": [{"Zone": dict(zone)} for zone in self.zones.values()]}
+
+    def _arm(self, mode, sub_id):
+        self.arm_calls.append((mode, sub_id))
+        if self.refuse_arm:
+            return False
+        for sub in self.subsystems:
+            if sub_id is None or sub["id"] == sub_id:
+                sub["arming"] = mode
+        return True
+
+    def arm_home(self, sub_id=None):
+        return self._arm("stay", sub_id)
+
+    def arm_away(self, sub_id=None):
+        return self._arm("away", sub_id)
+
+    def disarm(self, sub_id=None):
+        for sub in self.subsystems:
+            if sub_id is None or sub["id"] == sub_id:
+                sub["arming"] = "disarm"
+        return True
+
+    def make_request(self, endpoint, method, data=None, is_json=False):
+        if "control/arm/" in endpoint:
+            # Used by the integration for arm modes hikaxpro does not
+            # expose (vacation).
+            sid = endpoint.split("control/arm/")[1].split("?")[0]
+            sub_id = None if sid == "0xffffffff" else int(sid)
+            ways = endpoint.split("ways=")[1].split("&")[0]
+            if not self._arm(ways, sub_id):
+                return MockResponse(json_data={})
+            return MockResponse(json_data={"statusCode": 1})
+        if "status/zones" in endpoint:
+            if self.zone_status_fail:
+                raise ConnectionError("zone status unavailable")
+            return MockResponse(json_data=self.zone_status())
+        if "deviceInfo" in endpoint:
+            return MockResponse(text=DEVICE_INFO_XML)
+        if "Configuration/zones" in endpoint:
+            return MockResponse(
+                json_data={"List": [{"Zone": dict(cfg)} for cfg in self.zone_configs]}
+            )
+        if "Configuration/outputs" in endpoint:
+            return MockResponse(json_data={"List": []})
+        if "exDevStatus" in endpoint:
+            return MockResponse(json_data={})
+        return MockResponse(status_code=404, text=f"no mock for {endpoint}")
+
+
+@pytest.fixture
+def panel():
+    """A default panel: door zone 1 + PIR zone 2."""
+    mock = MockAxPro(
+        zones=[
+            zone_payload(1, name="Front door", magnet_open=False),
+            zone_payload(2, name="Curtain hall"),
+        ]
+    )
+    with patch("hikaxpro.HikAxPro", return_value=mock):
+        yield mock
+
+
+def make_entry(
+    hass, entry_id: str = "test-entry", **overrides
+) -> MockConfigEntry:
+    """Create and register a config entry with sane defaults."""
+    data = {
+        CONF_HOST: "1.2.3.4",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "secret",
+        CONF_ENABLED: False,
+        ATTR_CODE_FORMAT: "NUMBER",
+        CONF_CODE: "",
+        USE_CODE_ARMING: False,
+        CONF_SCAN_INTERVAL: 30,
+        ALLOW_SUBSYSTEMS: False,
+    }
+    data.update(overrides)
+    entry = MockConfigEntry(domain=DOMAIN, data=data, entry_id=entry_id)
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def setup_entry(hass, **overrides) -> MockConfigEntry:
+    """Set up the integration and wait for it to settle."""
+    entry = make_entry(hass, **overrides)
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+    return entry
+
+
+def get_coordinator(hass, entry):
+    return hass.data[DOMAIN][entry.entry_id][DATA_COORDINATOR]

--- a/tests/test_arming_flow.py
+++ b/tests/test_arming_flow.py
@@ -1,0 +1,277 @@
+"""Tests for the auto-bypass arming flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from pytest_homeassistant_custom_component.common import async_capture_events
+
+from custom_components.hikvision_axpro.const import (
+    CONF_AUTO_BYPASS_MODES,
+    DOMAIN,
+    EVENT_ARMING_BLOCKED,
+    EVENT_BYPASS_APPLIED,
+)
+
+from .conftest import get_coordinator, get_manager, setup_entry
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+PANEL_ENTITY = "alarm_control_panel"
+
+
+def panel_entity_id(hass) -> str:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        PANEL_ENTITY, DOMAIN, "001122334455"
+    )
+    assert entity_id
+    return entity_id
+
+
+async def arm_away(hass, blocking=True):
+    await hass.services.async_call(
+        PANEL_ENTITY,
+        "alarm_arm_away",
+        {"entity_id": panel_entity_id(hass)},
+        blocking=blocking,
+    )
+    await hass.async_block_till_done()
+
+
+async def test_arm_with_no_faults_sends_plain_arm(hass, panel):
+    """Healthy zones => no bypass calls, arm goes through."""
+    await setup_entry(hass)
+    await arm_away(hass)
+    assert panel.arm_calls == [("away", None)]
+    assert panel.bypass_calls == []
+    assert panel.area()["arming"] == "away"
+
+
+async def test_arm_bypasses_faulted_bypassable_zone(hass, panel):
+    """Open door marked bypassable is bypassed, then armed."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = get_manager(hass, entry)
+
+    events = async_capture_events(hass, EVENT_BYPASS_APPLIED)
+    await arm_away(hass)
+
+    assert panel.bypass_calls == [1]
+    assert panel.zones[1]["bypassed"] is True
+    assert panel.arm_calls == [("away", None)]
+    assert manager.owns_zone(1)
+    assert len(events) == 1
+    assert events[0].data["zone_id"] == 1
+    assert events[0].data["reason"] == "auto_arm"
+
+
+async def test_arm_blocked_by_non_bypassable_zone(hass, panel):
+    """Offline curtain not bypassable => abort, no arm."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    panel.set_zone(2, status="offline")
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = get_manager(hass, entry)
+
+    events = async_capture_events(hass, EVENT_ARMING_BLOCKED)
+    with pytest.raises(HomeAssistantError) as excinfo:
+        await arm_away(hass)
+
+    assert panel.arm_calls == []
+    assert panel.bypass_calls == []
+    assert "Curtain hall" in str(excinfo.value)
+    assert len(events) == 1
+    assert [z["zone_id"] for z in events[0].data["blocking_zones"]] == [2]
+    assert panel.area()["arming"] == "disarm"
+
+
+async def test_rollback_on_partial_bypass_failure(hass, panel):
+    """Second bypass fails => first is rolled back, arming aborted."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    panel.set_zone(2, status="trigger")
+    panel.fail_bypass_zones.add(2)
+    entry = await setup_entry(hass, bypassable={"away": [1, 2]})
+    manager = get_manager(hass, entry)
+
+    with pytest.raises(HomeAssistantError):
+        await arm_away(hass)
+
+    assert panel.arm_calls == []
+    assert panel.zones[1]["bypassed"] is False  # rolled back
+    assert 1 in panel.unbypass_calls
+    assert not manager.owns_zone(1)
+    assert not manager.owns_zone(2)
+
+
+async def test_fresh_read_failure_aborts_arming(hass, panel):
+    """Zone read failure at arm time => abort, panel untouched."""
+    await setup_entry(hass)
+    panel.zone_status_fail = True
+    with pytest.raises(HomeAssistantError):
+        await arm_away(hass)
+    assert panel.arm_calls == []
+
+
+async def test_auto_bypass_disabled_behaves_like_upstream(hass, panel):
+    """With no mode enabled, no bypass logic runs at all."""
+    panel.set_zone(1, magnetOpenStatus=True)  # faulted zone present
+    entry = await setup_entry(
+        hass, bypassable={"away": [1]}, **{CONF_AUTO_BYPASS_MODES: []}
+    )
+    manager = get_manager(hass, entry)
+
+    await arm_away(hass)
+
+    assert panel.bypass_calls == []
+    assert panel.arm_calls == [("away", None)]
+
+
+async def test_mode_not_enabled_skips_flow(hass, panel):
+    """Auto-bypass enabled for away only: arming home is a plain arm."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(
+        hass, bypassable={"away": [1]}, **{CONF_AUTO_BYPASS_MODES: ["away"]}
+    )
+    manager = get_manager(hass, entry)
+
+    await hass.services.async_call(
+        PANEL_ENTITY,
+        "alarm_arm_home",
+        {"entity_id": panel_entity_id(hass)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert panel.bypass_calls == []
+    assert panel.arm_calls == [("stay", None)]
+
+
+async def test_panel_arm_refusal_raises(hass, panel):
+    """A refused arm command is surfaced as an error."""
+    await setup_entry(hass)
+    panel.refuse_arm = True
+    with pytest.raises(HomeAssistantError):
+        await arm_away(hass)
+
+
+async def test_concurrent_arm_rejected(hass, panel):
+    """A second arm while one is in progress is rejected."""
+    entry = await setup_entry(hass)
+    manager = get_manager(hass, entry)
+    coordinator = get_coordinator(hass, entry)
+    async with manager.arm_lock:
+        with pytest.raises(HomeAssistantError):
+            await coordinator.async_arm_away()
+    assert panel.arm_calls == []
+
+
+async def test_arm_home_also_runs_the_flow(hass, panel):
+    """User decision #8: all exposed arm modes are intercepted."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass, bypassable={"home": [1]})
+    manager = get_manager(hass, entry)
+
+    await hass.services.async_call(
+        PANEL_ENTITY,
+        "alarm_arm_home",
+        {"entity_id": panel_entity_id(hass)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert panel.bypass_calls == [1]
+    assert panel.arm_calls == [("stay", None)]
+
+
+async def test_arm_vacation_runs_the_flow(hass, panel):
+    """Vacation arming is supported and intercepted like the others."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass, bypassable={"vacation": [1]})
+    manager = get_manager(hass, entry)
+
+    await hass.services.async_call(
+        PANEL_ENTITY,
+        "alarm_arm_vacation",
+        {"entity_id": panel_entity_id(hass)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert panel.bypass_calls == [1]
+    assert panel.arm_calls == [("vacation", None)]
+    assert panel.area()["arming"] == "vacation"
+
+    # The entity state reflects the vacation arming on the next poll.
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+    state = hass.states.get(panel_entity_id(hass))
+    assert state.state in {"armed_vacation", "unknown"}
+
+
+async def test_forbid_bypass_on_arming_zone_blocks(hass, panel):
+    """Panel-side 'forbid bypass on arming' beats the HA bypassable flag.
+
+    The flag simply cannot be set for such a zone, so a fault on it
+    always blocks arming.
+    """
+    panel.zone_configs = [
+        {"id": 1, "zoneName": "Front door", "armNoBypassEnabled": True}
+    ]
+    panel.set_zone(1, magnetOpenStatus=True)
+    # Configured as bypassable, but the panel forbids bypassing it.
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = get_manager(hass, entry)
+    assert not manager.is_bypassable(1)
+
+    with pytest.raises(HomeAssistantError):
+        await arm_away(hass)
+
+    assert panel.bypass_calls == []
+    assert panel.arm_calls == []
+
+
+async def test_arm_home_ignores_stay_bypassed_zone(hass, panel):
+    """A faulted zone the panel stay-bypasses itself never blocks home."""
+    panel.set_zone(1, magnetOpenStatus=True, stayAway=True)
+    await setup_entry(hass)
+
+    await hass.services.async_call(
+        PANEL_ENTITY,
+        "alarm_arm_home",
+        {"entity_id": panel_entity_id(hass)},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert panel.bypass_calls == []
+    assert panel.arm_calls == [("stay", None)]
+
+
+async def test_arm_with_bypass_service_forces_the_flow(hass, panel):
+    """arm_away_with_bypass bypasses even when the mode has auto-bypass off."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    await setup_entry(
+        hass, bypassable={"away": [1]}, **{CONF_AUTO_BYPASS_MODES: []}
+    )
+
+    await hass.services.async_call(
+        DOMAIN, "arm_away_with_bypass", {}, blocking=True
+    )
+    await hass.async_block_till_done()
+
+    assert panel.bypass_calls == [1]
+    assert panel.area()["arming"] == "away"
+
+
+async def test_arm_with_bypass_still_respects_the_zone_selection(hass, panel):
+    """Forcing the flow does not bypass zones the user never picked."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    await setup_entry(hass, **{CONF_AUTO_BYPASS_MODES: []})
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, "arm_away_with_bypass", {}, blocking=True
+        )
+    assert panel.bypass_calls == []

--- a/tests/test_entities_services.py
+++ b/tests/test_entities_services.py
@@ -1,0 +1,444 @@
+"""Tests for services, the bypassable readback sensor and ready sensor."""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers.storage import Store
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import async_fire_time_changed
+
+from custom_components.hikvision_axpro.const import (
+    CONF_AUTO_BYPASS_MODES,
+    DOMAIN,
+    SERVICE_BYPASS_ZONE,
+    SERVICE_CLEAR_ALL_BYPASSES,
+    SERVICE_UNBYPASS_ZONE,
+    conf_bypassable_zones,
+)
+
+from .conftest import get_coordinator, get_manager, make_entry, setup_entry
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+
+def entity_id_of(hass, domain, unique_id) -> str:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
+    assert entity_id, f"entity {unique_id} not found"
+    return entity_id
+
+
+# ---------------------------------------------------------------------------
+# Services
+
+
+async def test_bypass_and_unbypass_services(hass, panel):
+    """Bypass/unbypass a zone by targeting its bypass sensor."""
+    entry = await setup_entry(hass)
+    manager = get_manager(hass, entry)
+    bypass_sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypass-1"
+    )
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_BYPASS_ZONE, {"entity_id": bypass_sensor}, blocking=True
+    )
+    await hass.async_block_till_done()
+    assert panel.zones[1]["bypassed"] is True
+    # User decision #5: service bypasses are owned by the integration.
+    assert manager.owns_zone(1)
+    assert manager.bypass_reason(1) == "service"
+
+    await hass.services.async_call(
+        DOMAIN, SERVICE_UNBYPASS_ZONE, {"entity_id": bypass_sensor}, blocking=True
+    )
+    await hass.async_block_till_done()
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+
+
+async def test_bypass_service_failure_raises(hass, panel):
+    """A failed service bypass surfaces an explicit error."""
+    await setup_entry(hass)
+    panel.fail_bypass_zones.add(1)
+    bypass_sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypass-1"
+    )
+
+    with pytest.raises(HomeAssistantError):
+        await hass.services.async_call(
+            DOMAIN, SERVICE_BYPASS_ZONE, {"entity_id": bypass_sensor}, blocking=True
+        )
+
+
+async def test_clear_all_bypasses_service(hass, panel):
+    """Clear all removes every bypass regardless of owner."""
+    entry = await setup_entry(hass)
+    panel.zones[1]["bypassed"] = True  # external
+    panel.zones[2]["bypassed"] = True  # external
+    panel_entity = entity_id_of(hass, "alarm_control_panel", "001122334455")
+
+    await hass.services.async_call(
+        DOMAIN,
+        SERVICE_CLEAR_ALL_BYPASSES,
+        {"entity_id": panel_entity},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert panel.zones[2]["bypassed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Bypassable readback sensor
+
+
+async def test_bypassable_sensor_reflects_the_configuration(hass, panel):
+    """Read-only: on for a configured zone, off for the others."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = get_manager(hass, entry)
+
+    configured = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-away-1"
+    )
+    other = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-away-2"
+    )
+    assert hass.states.get(configured).state == "on"
+    assert hass.states.get(other).state == "off"
+    assert manager.is_bypassable(1, "away")
+    assert not manager.is_bypassable(2, "away")
+
+
+async def test_no_bypassable_switch_is_created(hass, panel):
+    """The configuration moved to the options: no per-zone switch exists."""
+    await setup_entry(hass, bypassable={"away": [1]})
+    registry = er.async_get(hass)
+    assert not registry.async_get_entity_id(
+        "switch", DOMAIN, "001122334455-bypassable-away-1"
+    )
+
+
+async def test_bypassable_sensors_are_independent_per_mode(hass, panel):
+    entry = await setup_entry(hass, bypassable={"home": [1]})
+    manager = get_manager(hass, entry)
+    away = entity_id_of(hass, "binary_sensor", "001122334455-bypassable-away-1")
+    home = entity_id_of(hass, "binary_sensor", "001122334455-bypassable-home-1")
+    vacation = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-vacation-1"
+    )
+
+    assert hass.states.get(home).state == "on"
+    assert hass.states.get(away).state == "off"
+    assert hass.states.get(vacation).state == "off"
+
+    assert manager.is_bypassable(1, "home")
+    assert not manager.is_bypassable(1, "away")
+    assert not manager.is_bypassable(1, "vacation")
+
+
+async def test_bypassable_sensors_created_only_for_allowed_modes(hass, panel):
+    """Disallowed modes do not expose a per-zone bypassable sensor."""
+    await setup_entry(hass, **{CONF_AUTO_BYPASS_MODES: ["away"]})
+    registry = er.async_get(hass)
+
+    assert registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-away-1"
+    )
+    assert not registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-home-1"
+    )
+    assert not registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-vacation-1"
+    )
+
+
+async def test_configuration_survives_a_reload(hass, panel):
+    """The selection lives in the config entry, so a restart keeps it."""
+    entry = await setup_entry(hass, bypassable={"home": [1]})
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    reloaded = get_manager(hass, entry)
+    assert reloaded.is_bypassable(1, "home")
+    assert not reloaded.is_bypassable(1, "away")
+    sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-home-1"
+    )
+    assert hass.states.get(sensor).state == "on"
+
+
+async def test_bypassable_sensor_off_when_panel_forbids(hass, panel):
+    """'Forbid bypass on arming' (panel config) wins over the options."""
+    panel.zone_configs = [
+        {"id": 1, "zoneName": "Front door", "armNoBypassEnabled": True},
+        {"id": 2, "zoneName": "Curtain hall", "armNoBypassEnabled": False},
+    ]
+    entry = await setup_entry(hass, bypassable={"away": [1, 2]})
+    manager = get_manager(hass, entry)
+
+    forbidden = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-away-1"
+    )
+    normal = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-away-2"
+    )
+    assert hass.states.get(forbidden).state == "off"
+    assert hass.states.get(normal).state == "on"
+    assert not manager.is_bypassable(1, "away")
+
+    # The user's choice is not rewritten, only reported as ineffective.
+    assert manager.is_configured_bypassable(1, "away")
+    attrs = hass.states.get(forbidden).attributes
+    assert attrs["configured"] is True
+    assert attrs["ineffective_reason"] == "forbidden_by_panel_config"
+
+
+async def test_panel_forbid_change_picked_up_on_hourly_refresh(hass, panel):
+    """Enabling the panel setting takes effect at the hourly config refresh."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    coordinator = get_coordinator(hass, entry)
+    manager = get_manager(hass, entry)
+    assert manager.is_bypassable(1, "away")
+    sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypassable-away-1"
+    )
+
+    panel.zone_configs = [
+        {"id": 1, "zoneName": "Front door", "armNoBypassEnabled": True}
+    ]
+
+    # Within the hour the config is not re-fetched: nothing changes yet.
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+    assert manager.is_bypassable(1, "away")
+
+    # Backdate the last fetch so the hourly refresh is due.
+    coordinator._last_zone_config_fetch -= timedelta(hours=2)
+    await coordinator.async_refresh()
+    await hass.async_block_till_done()
+
+    assert not manager.is_bypassable(1, "away")
+    assert hass.states.get(sensor).state == "off"
+
+
+async def test_stale_bypassable_sensor_removed_on_zone_type_change(hass, panel):
+    """A sensor left over from a zone type change is removed on reload."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+    for mode in ("away", "home", "vacation"):
+        assert registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"001122334455-bypassable-{mode}-1"
+        )
+
+    panel.zones[1]["zoneType"] = "Delay"  # no longer eligible
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for mode in ("away", "home", "vacation"):
+        assert not registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, f"001122334455-bypassable-{mode}-1"
+        )
+
+
+async def test_legacy_bypassable_switch_is_removed(hass, panel):
+    """The per-zone switch of earlier builds is cleaned out of the registry."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    for unique_id in (
+        "001122334455-bypassable-away-1",
+        "001122334455-bypassable-1",
+    ):
+        registry.async_get_or_create(
+            "switch", DOMAIN, unique_id, config_entry=entry
+        )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    for unique_id in (
+        "001122334455-bypassable-away-1",
+        "001122334455-bypassable-1",
+    ):
+        assert not registry.async_get_entity_id("switch", DOMAIN, unique_id)
+
+
+async def test_configured_zone_that_became_ineligible_is_inert(hass, panel):
+    """A zone type change makes the configuration ineffective, not lost."""
+    entry = await setup_entry(hass, bypassable={"away": [1], "home": [1]})
+    manager = get_manager(hass, entry)
+    assert manager.is_bypassable(1, "away")
+    assert manager.is_bypassable(1, "home")
+
+    panel.zones[1]["zoneType"] = "Delay"
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    assert not manager.is_bypassable(1, "away")
+    assert not manager.is_bypassable(1, "home")
+    assert entry.data[conf_bypassable_zones("away")] == [1]
+
+
+async def test_no_bypassable_sensor_for_excluded_zone_types(hass, panel):
+    """No readback sensor for zone types that are never auto-bypassed."""
+    panel.zones[3] = {
+        "id": 3,
+        "name": "Smoke",
+        "status": "online",
+        "tamperEvident": False,
+        "bypassed": False,
+        "armed": False,
+        "alarm": False,
+        "subSystemNo": 1,
+        "zoneType": "Fire",
+    }
+    await setup_entry(hass)
+    registry = er.async_get(hass)
+    assert registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-away-1"
+    )
+    assert not registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-away-3"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ready-to-arm sensor
+
+
+async def test_ready_sensor_reflects_evaluation(hass, panel):
+    entry = await setup_entry(hass)
+    sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-ready-to-arm-away"
+    )
+    assert hass.states.get(sensor).state == "on"
+
+    panel.set_zone(2, status="offline")  # non-bypassable fault
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(sensor)
+    assert state.state == "off"
+    assert [z["zone_id"] for z in state.attributes["blocking_zones"]] == [2]
+    assert state.attributes["areas"]["1"]["ready"] is False
+
+
+async def test_ready_sensor_counts_configured_zones_as_bypassable(hass, panel):
+    """A faulted but configured zone is listed to bypass, not as blocking."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-ready-to-arm-away"
+    )
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    state = hass.states.get(sensor)
+    assert state.state == "on"
+    assert [z["zone_id"] for z in state.attributes["zones_to_bypass"]] == [1]
+
+
+async def test_ready_sensor_blocks_on_an_unconfigured_faulted_zone(hass, panel):
+    """Without the option set, the same fault blocks arming."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass)
+    sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-ready-to-arm-away"
+    )
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+    assert hass.states.get(sensor).state == "off"
+
+
+async def test_ready_sensor_uses_the_mode_specific_selection(hass, panel):
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(hass, bypassable={"home": [1]})
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    away = entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-away")
+    home = entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-home")
+
+    assert hass.states.get(away).state == "off"
+    assert hass.states.get(home).state == "on"
+
+
+async def test_ready_sensor_created_for_every_mode(hass, panel):
+    """One ready sensor per arming mode, regardless of auto-bypass config."""
+    await setup_entry(hass, **{CONF_AUTO_BYPASS_MODES: []})
+    for unique_id in (
+        "001122334455-ready-to-arm-away",
+        "001122334455-ready-to-arm-home",
+        "001122334455-ready-to-arm-vacation",
+    ):
+        entity_id_of(hass, "binary_sensor", unique_id)
+
+
+async def test_ready_sensor_applies_the_mode_gate_first(hass, panel):
+    """A disallowed mode ignores the selection and still blocks."""
+    panel.set_zone(1, magnetOpenStatus=True)
+    entry = await setup_entry(
+        hass, bypassable={"home": [1]}, **{CONF_AUTO_BYPASS_MODES: ["away"]}
+    )
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    home = entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-home")
+    assert hass.states.get(home).state == "off"
+
+
+async def test_home_ready_sensor_ignores_stay_bypassed_zone(hass, panel):
+    """A stay-bypassed faulted zone blocks away but not home."""
+    panel.set_zone(2, status="offline", stayAway=True)
+    entry = await setup_entry(hass)
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    away = entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-away")
+    home = entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-home")
+    assert hass.states.get(away).state == "off"
+    assert hass.states.get(home).state == "on"
+    assert hass.states.get(home).attributes["evaluated_mode"] == "home"
+
+
+async def test_panel_diagnostic_attributes(hass, panel):
+    """The panel exposes bypassed zones and owned bypasses."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    panel.set_zone(1, magnetOpenStatus=True)
+    await get_coordinator(hass, entry).async_arm_away()
+    # Entity states update on the next poll cycle.
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+    panel_entity = entity_id_of(hass, "alarm_control_panel", "001122334455")
+    attrs = hass.states.get(panel_entity).attributes
+    assert [z["zone_id"] for z in attrs["bypassed_zones"]] == [1]
+    assert "1" in {str(k) for k in attrs["owned_bypasses"]}
+    assert attrs["last_auto_bypass"] is not None
+
+    bypass_sensor = entity_id_of(
+        hass, "binary_sensor", "001122334455-bypass-1"
+    )
+    sensor_attrs = hass.states.get(bypass_sensor).attributes
+    assert sensor_attrs["bypass_owner"] == "integration"
+    assert sensor_attrs["bypass_reason"] == "auto_arm"
+
+
+async def test_unreadable_bypass_storage_does_not_block_setup(hass, panel):
+    """Everything stored is recoverable, so a bad file is just discarded."""
+    store = Store[dict](hass, 99, "hikvision_axpro.test-entry.bypass")
+    await store.async_save({"owned_bypasses": "not-a-dict"})
+
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+
+    manager = get_manager(hass, entry)
+    assert manager.store.data.owned_bypasses == {}
+    # The configuration lives in the entry, so it is unaffected.
+    assert manager.is_bypassable(1, "away")

--- a/tests/test_entity_id.py
+++ b/tests/test_entity_id.py
@@ -2,68 +2,42 @@
 
 from __future__ import annotations
 
-import importlib.util
 import re
-import sys
-import types
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 
-ROOT = Path(__file__).resolve().parents[1]
-COMPONENT = ROOT / "custom_components" / "hikvision_axpro"
+from custom_components.hikvision_axpro.entity_id import (
+    build_entity_id,
+    has_invalid_object_id_chars,
+    normalized_mac,
+    normalized_object_id,
+)
+from custom_components.hikvision_axpro.model import DetectorType, zone_device_model
+
+COMPONENT = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "hikvision_axpro"
+)
+
+PLATFORM_FILES = (
+    "binary_sensor.py",
+    "sensor.py",
+    "switch.py",
+    "button.py",
+    "host_entities.py",
+    "peripheral_entities.py",
+    "siren_entities.py",
+)
+
+MAC = "a4d5c26bb859"
 
 
-def _install_ha_stubs() -> None:
-    """Minimal homeassistant stubs so entity_id can load without full HA."""
-    _ha = types.ModuleType("homeassistant")
-    _ha_config_entries = types.ModuleType("homeassistant.config_entries")
-    _ha_core = types.ModuleType("homeassistant.core")
-    _ha_helpers = types.ModuleType("homeassistant.helpers")
-    _ha_entity_registry = types.ModuleType("homeassistant.helpers.entity_registry")
-    _ha_util = types.ModuleType("homeassistant.util")
-
-    def _fake_slugify(text: str) -> str:
-        text = (text or "").lower()
-        text = re.sub(r"[^a-z0-9]+", "_", text)
-        return text.strip("_")
-
-    _ha_util.slugify = _fake_slugify
-    _ha_config_entries.ConfigEntry = object
-    _ha_core.HomeAssistant = object
-    _ha_entity_registry.async_get = MagicMock()
-    _ha_entity_registry.async_entries_for_config_entry = MagicMock(return_value=[])
-    _ha_helpers.entity_registry = _ha_entity_registry
-
-    sys.modules.setdefault("homeassistant", _ha)
-    sys.modules.setdefault("homeassistant.config_entries", _ha_config_entries)
-    sys.modules.setdefault("homeassistant.core", _ha_core)
-    sys.modules.setdefault("homeassistant.helpers", _ha_helpers)
-    sys.modules.setdefault(
-        "homeassistant.helpers.entity_registry", _ha_entity_registry
-    )
-    sys.modules.setdefault("homeassistant.util", _ha_util)
-
-
-def _load_module(name: str, path: Path):
-    spec = importlib.util.spec_from_file_location(name, path)
-    assert spec and spec.loader
-    module = importlib.util.module_from_spec(spec)
-    sys.modules[name] = module
-    spec.loader.exec_module(module)
-    return module
-
-
-_install_ha_stubs()
-entity_id = _load_module("hikvision_axpro_entity_id", COMPONENT / "entity_id.py")
-model = _load_module("hikvision_axpro_model", COMPONENT / "model.py")
-
-build_entity_id = entity_id.build_entity_id
-has_invalid_object_id_chars = entity_id.has_invalid_object_id_chars
-normalized_object_id = entity_id.normalized_object_id
-DetectorType = model.DetectorType
-zone_device_model = model.zone_device_model
+def test_normalized_mac_is_one_compact_token() -> None:
+    """A MAC is one identifier, so it stays one token."""
+    assert normalized_mac("A4:D5:C2:6B:B8:59") == MAC
+    assert normalized_mac("a4-d5-c2-6b-b8-59") == MAC
+    assert normalized_mac(MAC) == MAC
+    assert normalized_mac(None) == ""
 
 
 def test_normalized_object_id_slugifies() -> None:
@@ -72,10 +46,14 @@ def test_normalized_object_id_slugifies() -> None:
     assert re.fullmatch(r"[a-z0-9_]+", normalized_object_id("Český ***", "Zone 7"))
 
 
-def test_normalized_object_id_fallback_hash() -> None:
-    result = normalized_object_id("***", fallback="")
+def test_normalized_object_id_falls_back_then_hashes() -> None:
+    assert normalized_object_id("", fallback="Zone 7") == "zone_7"
+
+    # Nothing sluggable at all: a deterministic id rather than an empty one.
+    result = normalized_object_id("", fallback="")
     assert result.startswith("entity_")
     assert re.fullmatch(r"[a-z0-9_]+", result)
+    assert normalized_object_id("", fallback="") == result
 
 
 def test_has_invalid_object_id_chars() -> None:
@@ -84,15 +62,95 @@ def test_has_invalid_object_id_chars() -> None:
     assert not has_invalid_object_id_chars("sensor.ax_pro_temperature_0")
 
 
-def test_build_entity_id_shape() -> None:
+def test_build_entity_id_is_device_zone_name_mac() -> None:
+    """``<device>_z<zone>_<name>_<compact mac>`` for zone entities."""
     assert (
-        build_entity_id("sensor", "AX PRO", "temperature", 0)
-        == "sensor.ax_pro_temperature_0"
+        build_entity_id("binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z")
+        == "binary_sensor.ingresso_z1_tamper_a4d5c26bb859"
     )
     assert (
-        build_entity_id("binary_sensor", "AX PRO", "magnet-shock", 8)
-        == "binary_sensor.ax_pro_magnet_shock_8"
+        build_entity_id("binary_sensor", f"{MAC}-magnet-shock-8", MAC, "garage", "z")
+        == "binary_sensor.garage_z8_magnet_shock_a4d5c26bb859"
     )
+    assert (
+        build_entity_id("sensor", f"{MAC}-temp-12", MAC, "cucina_tenda", "z")
+        == "sensor.cucina_tenda_z12_temp_a4d5c26bb859"
+    )
+
+
+def test_only_real_zone_numbers_are_marked_with_z() -> None:
+    """A hub battery or a relay is not a zone, so it keeps a plain number."""
+    assert (
+        build_entity_id("sensor", f"{MAC}-hub-battery-1", MAC, "alarm")
+        == "sensor.alarm_hub_battery_1_a4d5c26bb859"
+    )
+    assert (
+        build_entity_id("switch", f"{MAC}-relay-2", MAC, "garage door")
+        == "switch.garage_door_relay_2_a4d5c26bb859"
+    )
+
+
+def test_zone_number_is_marked_so_it_cannot_read_as_a_dedup_suffix() -> None:
+    """``z1`` rather than a bare trailing ``_1``."""
+    entity_id = build_entity_id(
+        "binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z"
+    )
+    assert "_z1_" in entity_id
+    # The MAC always closes the id, so nothing can trail as a suffix.
+    assert entity_id.endswith(MAC)
+    assert not re.search(r"_\d+$", entity_id)
+
+
+def test_build_entity_id_does_not_repeat_the_device_name() -> None:
+    """A device already saying it is not made to say it twice."""
+    assert (
+        build_entity_id(
+            "binary_sensor", f"{MAC}-alarm-1", MAC, "Front door alarm", "z"
+        )
+        == "binary_sensor.front_door_alarm_z1_a4d5c26bb859"
+    )
+    # An area panel whose name already ends in its own number.
+    assert (
+        build_entity_id("alarm_control_panel", f"subsys-{MAC}-1", MAC, "Area 1")
+        == "alarm_control_panel.area_1_subsys_a4d5c26bb859"
+    )
+
+
+def test_build_entity_id_without_a_zone_number() -> None:
+    """Panel-level entities simply have no zone marker."""
+    assert (
+        build_entity_id("binary_sensor", f"{MAC}-ac-power", MAC, "alarm")
+        == "binary_sensor.alarm_ac_power_a4d5c26bb859"
+    )
+    assert (
+        build_entity_id("binary_sensor", f"{MAC}-ready-to-arm-away", MAC, "alarm")
+        == "binary_sensor.alarm_ready_to_arm_away_a4d5c26bb859"
+    )
+    # The panel entity's unique_id is the MAC alone.
+    assert build_entity_id("alarm_control_panel", MAC, MAC, "alarm") == (
+        "alarm_control_panel.alarm_a4d5c26bb859"
+    )
+
+
+def test_build_entity_id_never_needs_a_dedup_suffix() -> None:
+    """Two panels with identically named zones still get distinct ids."""
+    other = "a4d5c26bb85a"
+    first = build_entity_id("binary_sensor", f"{MAC}-tamper-1", MAC, "ingresso", "z")
+    second = build_entity_id(
+        "binary_sensor", f"{other}-tamper-1", other, "ingresso", "z"
+    )
+    assert first != second
+    assert not first.endswith("_2") and not second.endswith("_2")
+
+
+def test_generated_ids_use_underscore_only_as_separator() -> None:
+    for unique_id in (f"{MAC}-tamper-1", f"{MAC}-magnet-shock-8", f"{MAC}-ac-power"):
+        _, object_id = build_entity_id(
+            "sensor", unique_id, MAC, "ingresso", "z"
+        ).split(".", 1)
+        assert re.fullmatch(r"[a-z0-9]+(_[a-z0-9]+)*", object_id)
+        # The MAC stays one token instead of becoming six.
+        assert MAC in object_id
 
 
 def test_zone_device_model_always_str() -> None:
@@ -105,14 +163,17 @@ def test_zone_device_model_always_str() -> None:
     assert zone_device_model(None, None) == "Unknown"
 
 
-@pytest.mark.parametrize(
-    "filename",
-    ("binary_sensor.py", "sensor.py", "switch.py"),
-)
-def test_platforms_do_not_assign_raw_device_name_entity_id(filename: str) -> None:
+@pytest.mark.parametrize("filename", PLATFORM_FILES)
+def test_platforms_derive_entity_id_from_unique_id(filename: str) -> None:
+    """No platform hand-rolls an entity id from a name."""
     content = (COMPONENT / filename).read_text(encoding="utf-8")
     assert "build_entity_id(" in content
-    assert not re.search(
-        r'self\.entity_id\s*=\s*f?["\'].*coordinator\.device_name',
-        content,
-    )
+    assert not re.search(r'self\.entity_id\s*=\s*f?["\']', content)
+
+
+@pytest.mark.parametrize("filename", PLATFORM_FILES)
+def test_unique_ids_are_compact_mac_scoped(filename: str) -> None:
+    """unique_ids key off the compact MAC, not the panel name."""
+    content = (COMPONENT / filename).read_text(encoding="utf-8")
+    assert "device_name}-" not in content
+    assert "coordinator.mac}-" not in content

--- a/tests/test_entity_id_migration.py
+++ b/tests/test_entity_id_migration.py
@@ -1,0 +1,364 @@
+"""Integration-level tests for entity ID generation and migration."""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import patch
+
+import pytest
+
+from homeassistant.helpers import entity_registry as er
+
+import custom_components.hikvision_axpro as integration_init
+from custom_components.hikvision_axpro.const import DOMAIN
+
+from .conftest import MockAxPro, make_entry, setup_entry, zone_payload
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+
+def entity_id_of(hass, domain: str, unique_id: str) -> str:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
+    assert entity_id, f"entity {unique_id} not found"
+    return entity_id
+
+
+async def test_generated_ids_use_underscore_only_as_separator(hass, panel):
+    """Generated ids are ``<device>_<what>`` slugs, never MAC soup."""
+    await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    entries = [
+        reg
+        for reg in registry.entities.values()
+        if reg.platform == DOMAIN and reg.unique_id
+    ]
+    assert entries, "no entities were created"
+
+    for reg in entries:
+        _, object_id = reg.entity_id.split(".", 1)
+        assert re.fullmatch(r"[a-z0-9]+(_[a-z0-9]+)*", object_id), reg.entity_id
+        # The MAC is an internal identifier: it must never leak into an id.
+        assert "00_11_22" not in object_id
+
+
+async def test_entity_ids_are_device_zone_name_mac(hass, panel):
+    """``<device>_z<zone>_<name>_<compact mac>``."""
+    await setup_entry(hass)
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.front_door_z1_tamper_001122334455"
+    )
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-armed-1")
+        == "binary_sensor.front_door_z1_armed_001122334455"
+    )
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-bypass-2")
+        == "binary_sensor.curtain_hall_z2_bypass_001122334455"
+    )
+    # Panel-level entities carry the panel name and no zone number.
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "001122334455")
+        == "alarm_control_panel.axpro_001122334455"
+    )
+
+
+async def test_same_zone_name_never_needs_a_dedup_suffix(hass, panel):
+    """Two zones sharing a name stay distinct through the MAC and zone id."""
+    panel.zones[1]["name"] = "Front door alarm"
+    panel.zones[2]["name"] = "Front door alarm"  # same name as zone 1
+    await setup_entry(hass)
+
+    first = entity_id_of(hass, "binary_sensor", "001122334455-alarm-1")
+    second = entity_id_of(hass, "binary_sensor", "001122334455-alarm-2")
+    # The device name already ends in "alarm", so it is not repeated,
+    # and the zone number is marked with "z" rather than trailing bare.
+    assert first == "binary_sensor.front_door_alarm_z1_001122334455"
+    assert second == "binary_sensor.front_door_alarm_z2_001122334455"
+    # Identical zone names, yet no Home Assistant dedup suffix was added.
+    assert not first.endswith("_2") and not second.endswith("_2")
+
+
+async def test_migration_renames_invalid_registry_id_and_is_idempotent(
+    hass, panel, monkeypatch
+):
+    """Invalid ids are renamed in place; a second run changes nothing."""
+    entry = await setup_entry(hass)
+    old_entity_id = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+
+    # HA no longer accepts writing invalid ids directly; emulate a legacy
+    # invalid entry by forcing the migration logic onto this entity.
+    monkeypatch.setattr(
+        integration_init,
+        "has_invalid_object_id_chars",
+        lambda entity_id: entity_id == old_entity_id,
+    )
+    monkeypatch.setattr(
+        integration_init,
+        "normalized_object_id",
+        lambda value, fallback=None: "front_door_tamper_fixed",
+    )
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == "binary_sensor.front_door_tamper_fixed"
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert entity_id_of(hass, "binary_sensor", "001122334455-tamper-1") == migrated
+
+
+async def test_migration_collision_falls_back_with_suffix(hass, panel, monkeypatch):
+    """Collisions get a numeric suffix instead of failing setup."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    tamper = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    armed = entity_id_of(hass, "binary_sensor", "001122334455-armed-1")
+
+    registry.async_update_entity(armed, new_entity_id="binary_sensor.taken_slug")
+    registry.async_update_entity(tamper, new_entity_id="binary_sensor.needs_migration")
+
+    monkeypatch.setattr(
+        integration_init,
+        "has_invalid_object_id_chars",
+        lambda entity_id: entity_id == "binary_sensor.needs_migration",
+    )
+    monkeypatch.setattr(
+        integration_init,
+        "normalized_object_id",
+        lambda value, fallback=None: "taken_slug",
+    )
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.taken_slug_2"
+    )
+
+
+async def test_migration_leaves_existing_valid_ids_untouched(hass, panel):
+    """Upgrading an existing installation does not rename anything valid."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    before = {
+        reg.unique_id: reg.entity_id
+        for reg in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if reg.unique_id
+    }
+    assert before
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    after = {
+        reg.unique_id: reg.entity_id
+        for reg in er.async_entries_for_config_entry(registry, entry.entry_id)
+        if reg.unique_id
+    }
+    assert before == after
+
+
+async def test_legacy_device_name_unique_ids_are_rekeyed_to_the_mac(hass, panel):
+    """An install keyed by deviceName keeps its entities after the upgrade."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "axpro-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+    registry.async_update_entity(legacy.entity_id, name="My tamper")
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Re-keyed in place: same registry row, so name and history survive.
+    assert registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, "axpro-tamper-1"
+    ) is None
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == legacy.entity_id
+    assert registry.async_get(migrated).name == "My tamper"
+
+
+async def test_legacy_subsystem_unique_id_gets_a_separator(hass):
+    """``subsys-<mac><area>`` is ambiguous and becomes ``subsys-<mac>-<area>``."""
+    mock = MockAxPro(zones=[zone_payload(1, name="Front door", magnet_open=False)])
+    registry = er.async_get(hass)
+
+    with patch("hikaxpro.HikAxPro", return_value=mock):
+        entry = make_entry(hass, allow_subsystems=True)
+        registry.async_get_or_create(
+            "alarm_control_panel",
+            DOMAIN,
+            "subsys-00:11:22:33:44:551",
+            config_entry=entry,
+            suggested_object_id="area_1",
+        )
+
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "alarm_control_panel", DOMAIN, "subsys-00:11:22:33:44:551"
+        )
+        is None
+    )
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "subsys-001122334455-1")
+        == "alarm_control_panel.area_1"
+    )
+
+
+async def test_unique_id_migration_drops_a_duplicate_instead_of_failing(hass, panel):
+    """A half-migrated registry does not break setup."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "axpro-tamper-1",
+        config_entry=entry,
+        suggested_object_id="stale_tamper",
+    )
+    already_migrated = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "001122334455-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert registry.async_get("binary_sensor.stale_tamper") is None
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == already_migrated.entity_id
+    )
+
+
+async def test_user_renamed_entity_id_survives_setup(hass, panel):
+    """A user-chosen entity_id is never overwritten by the generator."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+
+    tamper = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    registry.async_update_entity(tamper, new_entity_id="binary_sensor.my_own_name")
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+        == "binary_sensor.my_own_name"
+    )
+
+
+async def test_colon_mac_unique_ids_are_compacted(hass, panel):
+    """``a4:d5:...-tamper-1`` becomes ``a4d5...-tamper-1`` in place."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "binary_sensor",
+        DOMAIN,
+        "00:11:22:33:44:55-tamper-1",
+        config_entry=entry,
+        suggested_object_id="front_door_tamper",
+    )
+    registry.async_update_entity(legacy.entity_id, name="My tamper")
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "binary_sensor", DOMAIN, "00:11:22:33:44:55-tamper-1"
+        )
+        is None
+    )
+    migrated = entity_id_of(hass, "binary_sensor", "001122334455-tamper-1")
+    assert migrated == legacy.entity_id
+    assert registry.async_get(migrated).name == "My tamper"
+
+
+async def test_colon_mac_panel_unique_id_is_compacted(hass, panel):
+    """The panel entity was keyed by the bare MAC; it is compacted too."""
+    registry = er.async_get(hass)
+    entry = make_entry(hass)
+    legacy = registry.async_get_or_create(
+        "alarm_control_panel",
+        DOMAIN,
+        "00:11:22:33:44:55",
+        config_entry=entry,
+        suggested_object_id="villa_1_alarm",
+    )
+
+    assert await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert (
+        registry.async_get_entity_id(
+            "alarm_control_panel", DOMAIN, "00:11:22:33:44:55"
+        )
+        is None
+    )
+    # The hand-picked entity_id survives the re-key.
+    assert (
+        entity_id_of(hass, "alarm_control_panel", "001122334455")
+        == legacy.entity_id
+        == "alarm_control_panel.villa_1_alarm"
+    )
+
+
+async def test_two_panels_with_identical_zone_names(hass):
+    """The reason the MAC is in the id: two panels, same zone names."""
+    names = ["ingresso", "bagno_pt", "cucina"]
+    registry = er.async_get(hass)
+
+    for entry_id, mac in (
+        ("panel-a", "a4:d5:c2:6b:b8:59"),
+        ("panel-b", "a4:d5:c2:6b:b8:5a"),
+    ):
+        mock = MockAxPro(
+            zones=[zone_payload(i, name=n) for i, n in enumerate(names, start=1)]
+        )
+        mock.get_interface_mac_address = lambda _iface, _mac=mac: _mac
+        with patch("hikaxpro.HikAxPro", return_value=mock):
+            entry = make_entry(hass, entry_id=entry_id)
+            assert await hass.config_entries.async_setup(entry.entry_id)
+            await hass.async_block_till_done()
+
+    rows = [
+        reg
+        for reg in registry.entities.values()
+        if reg.platform == DOMAIN and "-tamper-" in reg.unique_id
+    ]
+    # Nothing dropped by a unique_id collision: 3 zones x 2 panels.
+    assert len(rows) == 6
+    assert len({reg.unique_id for reg in rows}) == 6
+
+    entity_ids = {reg.entity_id for reg in rows}
+    assert len(entity_ids) == 6
+    assert entity_ids == {
+        "binary_sensor.ingresso_z1_tamper_a4d5c26bb859",
+        "binary_sensor.ingresso_z1_tamper_a4d5c26bb85a",
+        "binary_sensor.bagno_pt_z2_tamper_a4d5c26bb859",
+        "binary_sensor.bagno_pt_z2_tamper_a4d5c26bb85a",
+        "binary_sensor.cucina_z3_tamper_a4d5c26bb859",
+        "binary_sensor.cucina_z3_tamper_a4d5c26bb85a",
+    }

--- a/tests/test_entity_id_migration.py
+++ b/tests/test_entity_id_migration.py
@@ -61,8 +61,8 @@ async def test_entity_ids_are_device_zone_name_mac(hass, panel):
     )
     # Panel-level entities carry the panel name and no zone number.
     assert (
-        entity_id_of(hass, "alarm_control_panel", "001122334455")
-        == "alarm_control_panel.axpro_001122334455"
+        entity_id_of(hass, "binary_sensor", "001122334455-ready-to-arm-away")
+        == "binary_sensor.axpro_ready_to_arm_away_001122334455"
     )
 
 

--- a/tests/test_isapi_bypass.py
+++ b/tests/test_isapi_bypass.py
@@ -1,0 +1,123 @@
+"""Tests for the ISAPI bypass primitives."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hikvision_axpro.isapi_bypass import (
+    AxProBypassClient,
+    BypassCommandError,
+    BypassUnsupportedError,
+    BypassVerifyError,
+)
+
+from .conftest import MockAxPro, MockResponse, zone_payload
+
+
+def make_client(panel: MockAxPro, **kwargs) -> AxProBypassClient:
+    kwargs.setdefault("backoff_base", 0)
+    return AxProBypassClient(panel, **kwargs)
+
+
+def test_bypass_success_verified():
+    """Command + verification via state re-read."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+    client = make_client(panel)
+    client.bypass(1)
+    assert panel.zones[1]["bypassed"] is True
+    assert panel.bypass_calls == [1]
+
+    client.unbypass(1)
+    assert panel.zones[1]["bypassed"] is False
+
+
+def test_bypass_verify_mismatch_raises():
+    """The panel accepted the command but did not apply it."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+
+    original = panel.make_request
+
+    def lying_make_request(endpoint, method, data=None, is_json=False):
+        response = original(endpoint, method, data, is_json)
+        if "control/bypass/" in endpoint:
+            panel.zones[1]["bypassed"] = False  # panel silently ignored it
+        return response
+
+    panel.make_request = lying_make_request
+    client = make_client(panel)
+    with pytest.raises(BypassVerifyError):
+        client.bypass(1)
+
+
+def test_bypass_4xx_fails_fast():
+    """Client errors are not retried."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+    panel.fail_bypass_zones.add(1)
+    client = make_client(panel, max_retries=3)
+    with pytest.raises(BypassCommandError):
+        client.bypass(1)
+    assert panel.bypass_calls == [1]
+
+
+def test_unsupported_endpoint_raises_dedicated_error():
+    """404 means the firmware lacks the endpoint."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+
+    def gone(endpoint, method, data=None, is_json=False):
+        return MockResponse(status_code=404, text="not found")
+
+    panel.make_request = gone
+    client = make_client(panel)
+    with pytest.raises(BypassUnsupportedError):
+        client.bypass(1)
+
+
+def test_transient_errors_retried_with_limit():
+    """Retries on 5xx, then a clear error."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+    attempts = []
+
+    def flaky(endpoint, method, data=None, is_json=False):
+        attempts.append(endpoint)
+        return MockResponse(status_code=500, text="busy")
+
+    panel.make_request = flaky
+    client = make_client(panel, max_retries=3)
+    with pytest.raises(BypassCommandError):
+        client.bypass(1)
+    assert len(attempts) == 3
+
+
+def test_transient_error_then_success():
+    """A transient failure recovers on retry."""
+    panel = MockAxPro(zones=[zone_payload(1)])
+    original = panel.make_request
+    state = {"failed": False}
+
+    def flaky_once(endpoint, method, data=None, is_json=False):
+        if "control/bypass/" in endpoint and not state["failed"]:
+            state["failed"] = True
+            raise ConnectionError("blip")
+        return original(endpoint, method, data, is_json)
+
+    panel.make_request = flaky_once
+    client = make_client(panel, max_retries=3)
+    client.bypass(1)
+    assert panel.zones[1]["bypassed"] is True
+
+
+def test_detect_support():
+    """Feature detection from the zone status payload."""
+    with_bypass = {"ZoneList": [{"Zone": zone_payload(1)}]}
+    without = {"ZoneList": [{"Zone": {"id": 1, "name": "x", "armed": False}}]}
+    assert AxProBypassClient.detect_support(with_bypass) is True
+    assert AxProBypassClient.detect_support(without) is False
+    assert AxProBypassClient.detect_support(None) is False
+    assert AxProBypassClient.detect_support({}) is False
+
+
+def test_get_zone_raw():
+    panel = MockAxPro(zones=[zone_payload(1), zone_payload(2)])
+    client = make_client(panel)
+    assert client.get_zone_raw(2)["id"] == 2
+    assert client.get_zone_raw(99) is None

--- a/tests/test_lifecycle.py
+++ b/tests/test_lifecycle.py
@@ -1,0 +1,254 @@
+"""Tests for recovery, disarm cleanup, reconciliation and restart.
+"""
+
+from __future__ import annotations
+
+from datetime import timedelta
+
+import pytest
+
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import dt as dt_util
+from pytest_homeassistant_custom_component.common import (
+    async_capture_events,
+    async_fire_time_changed,
+)
+
+from custom_components.hikvision_axpro.const import DOMAIN, EVENT_BYPASS_REMOVED
+
+from .conftest import get_coordinator, get_manager, setup_entry
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+DEBOUNCE = 10
+
+
+async def poll(hass, entry):
+    await get_coordinator(hass, entry).async_refresh()
+    await hass.async_block_till_done()
+
+
+async def elapse(hass, seconds):
+    async_fire_time_changed(hass, dt_util.utcnow() + timedelta(seconds=seconds))
+    await hass.async_block_till_done()
+
+
+async def arm_away_with_open_door(hass, panel, entry):
+    """Arm away with zone 1 open+bypassable; returns with zone 1 owned.
+
+    The entry must have been set up with zone 1 bypassable on away.
+    """
+    manager = get_manager(hass, entry)
+    panel.set_zone(1, magnetOpenStatus=True)
+    registry = er.async_get(hass)
+    panel_id = registry.async_get_entity_id(
+        "alarm_control_panel", DOMAIN, "001122334455"
+    )
+    await hass.services.async_call(
+        "alarm_control_panel",
+        "alarm_arm_away",
+        {"entity_id": panel_id},
+        blocking=True,
+    )
+    await hass.async_block_till_done()
+    assert manager.owns_zone(1)
+    return manager
+
+
+async def test_reenable_after_recovery_and_debounce(hass, panel):
+    """Door closes while armed => bypass removed after debounce."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+    events = async_capture_events(hass, EVENT_BYPASS_REMOVED)
+
+    panel.set_zone(1, magnetOpenStatus=False)
+    await poll(hass, entry)
+    assert panel.zones[1]["bypassed"] is True  # debounce not elapsed yet
+
+    await elapse(hass, DEBOUNCE + 2)
+
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+    removal_events = [e for e in events if e.data["reason"] == "health_recovered"]
+    assert len(removal_events) == 1
+
+    # The zone is active again; reopening does not re-bypass it.
+    panel.set_zone(1, magnetOpenStatus=True)
+    await poll(hass, entry)
+    assert panel.bypass_calls == [1]
+    assert panel.zones[1]["bypassed"] is False
+
+
+async def test_no_reenable_while_unhealthy(hass, panel):
+    """The bypass is never removed while the zone is still open."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+
+    await poll(hass, entry)
+    await elapse(hass, DEBOUNCE * 10)
+
+    assert panel.zones[1]["bypassed"] is True
+    assert manager.owns_zone(1)
+    assert panel.unbypass_calls == []
+
+
+async def test_flapping_door_resets_debounce(hass, panel):
+    """Reopening during the debounce window cancels the re-enable."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+
+    panel.set_zone(1, magnetOpenStatus=False)
+    await poll(hass, entry)
+    panel.set_zone(1, magnetOpenStatus=True)  # reopened before debounce elapsed
+    await poll(hass, entry)
+    await elapse(hass, DEBOUNCE + 2)
+
+    assert panel.zones[1]["bypassed"] is True
+    assert manager.owns_zone(1)
+
+
+async def test_fresh_read_guard_before_reenable(hass, panel):
+    """A zone that reopens right before the timer fires is kept bypassed."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+
+    panel.set_zone(1, magnetOpenStatus=False)
+    await poll(hass, entry)
+    # Reopen WITHOUT a poll: only the fresh read at re-enable time can see it.
+    panel.set_zone(1, magnetOpenStatus=True)
+    await elapse(hass, DEBOUNCE + 2)
+
+    assert panel.zones[1]["bypassed"] is True
+    assert manager.owns_zone(1)
+    assert panel.unbypass_calls == []
+
+
+async def test_offline_zone_recovery(hass, panel):
+    """A zone bypassed because offline is restored once back online."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = get_manager(hass, entry)
+    panel.set_zone(1, status="offline")
+    coordinator = get_coordinator(hass, entry)
+    await coordinator.async_arm_away()
+    assert manager.owns_zone(1)
+
+    panel.set_zone(1, status="online")
+    await poll(hass, entry)
+    await elapse(hass, DEBOUNCE + 2)
+
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+
+
+async def test_cleanup_on_ha_disarm(hass, panel):
+    """Disarming through HA removes owned bypasses."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+    events = async_capture_events(hass, EVENT_BYPASS_REMOVED)
+
+    await get_coordinator(hass, entry).async_disarm()
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+    assert [e.data["reason"] for e in events] == ["disarm"]
+
+
+async def test_cleanup_on_external_disarm(hass, panel):
+    """A disarm from keypad/Hik-Connect also triggers cleanup."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+
+    panel.disarm()  # external: not through HA
+    await poll(hass, entry)
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+
+
+async def test_external_bypass_not_touched_on_disarm(hass, panel):
+    """Cleanup only removes integration-owned bypasses."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+    panel.zones[2]["bypassed"] = True  # applied via keypad/Hik-Connect
+
+    await get_coordinator(hass, entry).async_disarm()
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert panel.zones[2]["bypassed"] is True
+
+
+async def test_clear_all_on_disarm_option(hass, panel):
+    """Option: cleanup extends to all bypasses when enabled."""
+    entry = await setup_entry(
+        hass, bypassable={"away": [1]}, **{"clear_all_bypasses_on_disarm": True}
+    )
+    manager = await arm_away_with_open_door(hass, panel, entry)
+    panel.zones[2]["bypassed"] = True
+
+    await get_coordinator(hass, entry).async_disarm()
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert panel.zones[2]["bypassed"] is False
+    assert not manager.owns_zone(2)  # never took ownership of it
+
+
+async def test_refused_unbypass_retried_on_disarm(hass, panel):
+    """Firmware refusing unbypass while armed; disarm is the safety net."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+
+    panel.fail_unbypass_zones.add(1)
+    panel.set_zone(1, magnetOpenStatus=False)
+    await poll(hass, entry)
+    await elapse(hass, DEBOUNCE + 2)
+
+    assert panel.zones[1]["bypassed"] is True  # refused
+    assert manager.owns_zone(1)
+    assert manager.store.data.owned_bypasses[1].pending_unbypass is True
+
+    panel.fail_unbypass_zones.clear()
+    await get_coordinator(hass, entry).async_disarm()
+    await hass.async_block_till_done()
+
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)
+
+
+async def test_reconciliation_of_externally_removed_bypass(hass, panel):
+    """An owned bypass removed via keypad is dropped without errors."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    manager = await arm_away_with_open_door(hass, panel, entry)
+    events = async_capture_events(hass, EVENT_BYPASS_REMOVED)
+
+    # Removed externally; backdate ownership past the reconcile grace period.
+    panel.zones[1]["bypassed"] = False
+    manager.store.data.owned_bypasses[1].applied_at -= timedelta(seconds=60)
+    await poll(hass, entry)
+
+    assert not manager.owns_zone(1)
+    assert panel.unbypass_calls == []  # no blind unbypass
+    assert [e.data["reason"] for e in events] == ["reconciled"]
+
+
+async def test_ownership_survives_restart(hass, panel):
+    """Owned bypasses are rebuilt from storage after a reload."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+    await arm_away_with_open_door(hass, panel, entry)
+
+    await hass.config_entries.async_reload(entry.entry_id)
+    await hass.async_block_till_done()
+
+    manager = get_manager(hass, entry)
+    assert manager.owns_zone(1)
+    assert panel.zones[1]["bypassed"] is True
+
+    # The recovery logic resumes without manual intervention.
+    panel.set_zone(1, magnetOpenStatus=False)
+    await poll(hass, entry)
+    await elapse(hass, DEBOUNCE + 2)
+    assert panel.zones[1]["bypassed"] is False
+    assert not manager.owns_zone(1)

--- a/tests/test_options_flow.py
+++ b/tests/test_options_flow.py
@@ -1,0 +1,218 @@
+"""Tests for the per-mode bypassable zone pickers in the options flow."""
+
+from __future__ import annotations
+
+import pytest
+
+from homeassistant.const import (
+    ATTR_CODE_FORMAT,
+    CONF_CODE,
+    CONF_ENABLED,
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_SCAN_INTERVAL,
+    CONF_USERNAME,
+)
+from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import entity_registry as er
+
+from custom_components.hikvision_axpro.const import (
+    ALLOW_SUBSYSTEMS,
+    CONF_AUTO_BYPASS_MODES,
+    DOMAIN,
+    USE_CODE_ARMING,
+    conf_bypassable_zones,
+)
+
+from .conftest import setup_entry
+
+pytestmark = pytest.mark.usefixtures("auto_enable_custom_integrations")
+
+
+def base_input(**overrides) -> dict:
+    """The settings half of the options form."""
+    data = {
+        CONF_HOST: "1.2.3.4",
+        CONF_USERNAME: "admin",
+        CONF_PASSWORD: "secret",
+        CONF_ENABLED: False,
+        ATTR_CODE_FORMAT: "NUMBER",
+        CONF_CODE: "",
+        USE_CODE_ARMING: False,
+        CONF_SCAN_INTERVAL: 30,
+        ALLOW_SUBSYSTEMS: False,
+        CONF_AUTO_BYPASS_MODES: ["away"],
+        "bypass_reenable_debounce": 10,
+        "clear_all_bypasses_on_disarm": False,
+    }
+    data.update(overrides)
+    return data
+
+
+def bypass_entity(hass, zone_id: int) -> str:
+    registry = er.async_get(hass)
+    entity_id = registry.async_get_entity_id(
+        "binary_sensor", DOMAIN, f"001122334455-bypass-{zone_id}"
+    )
+    assert entity_id
+    return entity_id
+
+
+async def test_enabled_modes_get_a_zone_picker(hass, panel):
+    """A second step appears with one multiselect per enabled mode."""
+    entry = await setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        base_input(**{CONF_AUTO_BYPASS_MODES: ["home", "away"]}),
+    )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "bypass_zones"
+    keys = {str(key) for key in result["data_schema"].schema}
+    assert keys == {conf_bypassable_zones("home"), conf_bypassable_zones("away")}
+
+
+async def test_picked_entities_are_stored_as_zone_ids(hass, panel):
+    """The picker shows entities; the entry keeps the zone behind them."""
+    entry = await setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {conf_bypassable_zones("away"): [bypass_entity(hass, 1)]},
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    # Stored as a zone id, so renaming the entity cannot lose the setting.
+    assert entry.data[conf_bypassable_zones("away")] == [1]
+
+
+async def test_picker_only_offers_this_panel_entities(hass, panel):
+    """The choices are limited to zones of this config entry."""
+    entry = await setup_entry(hass)
+    registry = er.async_get(hass)
+    # An unrelated entity, and one from another integration.
+    registry.async_get_or_create(
+        "binary_sensor", "other_integration", "001122334455-bypass-9"
+    )
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+
+    selector = next(iter(result["data_schema"].schema.values()))
+    offered = set(selector.config["include_entities"])
+    assert offered == {bypass_entity(hass, 1), bypass_entity(hass, 2)}
+
+
+async def test_current_selection_is_prefilled_as_entities(hass, panel):
+    """Reopening the options shows the stored zones as their entities."""
+    entry = await setup_entry(hass, bypassable={"away": [2]})
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+
+    field = next(
+        key
+        for key in result["data_schema"].schema
+        if str(key) == conf_bypassable_zones("away")
+    )
+    assert field.default() == [bypass_entity(hass, 2)]
+
+
+async def test_disabling_a_mode_skips_the_picker_and_clears_it(hass, panel):
+    """With auto-bypass off, no selection is kept to come back later."""
+    entry = await setup_entry(hass, bypassable={"away": [1]})
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input(**{CONF_AUTO_BYPASS_MODES: []})
+    )
+    await hass.async_block_till_done()
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert conf_bypassable_zones("away") not in entry.data
+
+
+async def test_turning_one_mode_off_leaves_the_others_alone(hass, panel):
+    """Only the disabled mode loses its selection."""
+    entry = await setup_entry(hass, bypassable={"away": [1], "home": [2]})
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input(**{CONF_AUTO_BYPASS_MODES: ["home"]})
+    )
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {conf_bypassable_zones("home"): [bypass_entity(hass, 2)]},
+    )
+    await hass.async_block_till_done()
+
+    assert entry.data[conf_bypassable_zones("home")] == [2]
+    assert conf_bypassable_zones("away") not in entry.data
+
+
+async def test_saved_selection_takes_effect_after_the_reload(hass, panel):
+    """Saving the options re-arms the manager with the new zones."""
+    entry = await setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+    await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {conf_bypassable_zones("away"): [bypass_entity(hass, 1)]},
+    )
+    await hass.async_block_till_done()
+
+    from .conftest import get_manager
+
+    assert get_manager(hass, entry).is_bypassable(1, "away")
+    sensor = er.async_get(hass).async_get_entity_id(
+        "binary_sensor", DOMAIN, "001122334455-bypassable-away-1"
+    )
+    assert hass.states.get(sensor).state == "on"
+
+
+async def test_picker_omits_zones_the_panel_forbids_bypassing(hass, panel):
+    """A zone with "forbid bypass on arming" is not offered at all."""
+    panel.zone_configs = [
+        {"id": 1, "zoneName": "Front door", "armNoBypassEnabled": True},
+        {"id": 2, "zoneName": "Curtain hall", "armNoBypassEnabled": False},
+    ]
+    entry = await setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+
+    selector = next(iter(result["data_schema"].schema.values()))
+    offered = set(selector.config["include_entities"])
+    assert offered == {bypass_entity(hass, 2)}
+
+
+async def test_picker_omits_zone_types_that_are_never_bypassed(hass, panel):
+    """Only instant zones can be auto-bypassed, so only they are offered."""
+    panel.zones[1]["zoneType"] = "Delay"
+    entry = await setup_entry(hass)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"], base_input()
+    )
+
+    selector = next(iter(result["data_schema"].schema.values()))
+    offered = set(selector.config["include_entities"])
+    assert bypass_entity(hass, 1) not in offered
+    assert bypass_entity(hass, 2) in offered

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,0 +1,182 @@
+"""Tests for the pure policy functions."""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.hikvision_axpro.bypass_manager import (
+    evaluate_arm_readiness,
+    is_auto_bypass_eligible,
+    zone_fault_reason,
+    zone_in_area,
+)
+from custom_components.hikvision_axpro.const import (
+    ARM_MODE_AWAY,
+    ARM_MODE_HOME,
+    ARM_MODE_VACATION,
+)
+from custom_components.hikvision_axpro.model import Zone
+
+from .conftest import zone_payload
+
+
+def make_zone(**kwargs) -> Zone:
+    return Zone.from_dict(zone_payload(**kwargs))
+
+
+# ---------------------------------------------------------------------------
+# Fault definition
+
+
+@pytest.mark.parametrize(
+    ("fields", "expected"),
+    [
+        ({}, None),
+        ({"status": "trigger"}, "open"),
+        ({"alarm": True}, "open"),
+        ({"magnet_open": True}, "open"),
+        ({"status": "offline"}, "offline"),
+        ({"status": "breakDown"}, "offline"),
+        ({"status": "heartbeatAbnormal"}, "offline"),
+        ({"tamper": True}, "tamper"),
+        # tamper wins over open when both present
+        ({"tamper": True, "status": "trigger"}, "tamper"),
+        # low battery is a warning only (documented decision)
+        ({"charge": "lowPower"}, None),
+        # notRelated zones are ignored entirely
+        ({"status": "notRelated", "tamper": True}, None),
+    ],
+)
+def test_zone_fault_reason(fields, expected):
+    assert zone_fault_reason(make_zone(**fields)) == expected
+
+
+# ---------------------------------------------------------------------------
+# Zone type whitelist
+
+
+@pytest.mark.parametrize(
+    ("zone_type", "eligible"),
+    [
+        # Only instant zones are eligible: the panel offers the "forbid
+        # bypass on arming" option exclusively for them.
+        ("Instant", True),
+        ("Delay", False),
+        ("Perimeter", False),
+        ("Follow", False),
+        ("24h", False),
+        ("24hNoSound", False),
+        ("Fire", False),
+        ("Gas", False),
+        ("Medical", False),
+        ("Emergency", False),
+        ("Key", False),
+        ("Non-Alarm", False),
+        ("Timeout", False),
+    ],
+)
+def test_auto_bypass_zone_type_whitelist(zone_type, eligible):
+    assert is_auto_bypass_eligible(make_zone(zone_type=zone_type)) is eligible
+
+
+# ---------------------------------------------------------------------------
+# Area membership
+
+
+def test_zone_in_area():
+    zone = make_zone(sub_system_no=2)
+    assert zone_in_area(zone, None) is True
+    assert zone_in_area(zone, 2) is True
+    assert zone_in_area(zone, 1) is False
+
+
+def test_zone_in_area_linkage_fallback():
+    zone = Zone.from_dict(
+        {**zone_payload(1), "subSystemNo": None, "linkageSubSystem": [1, 3]}
+    )
+    assert zone_in_area(zone, 3) is True
+    assert zone_in_area(zone, 2) is False
+
+
+# ---------------------------------------------------------------------------
+# Readiness evaluation (single source of truth)
+
+
+def test_readiness_all_healthy():
+    zones = [make_zone(zone_id=1), make_zone(zone_id=2)]
+    result = evaluate_arm_readiness(zones, set())
+    assert result.ready is True
+    assert result.blocking_zones == []
+    assert result.zones_to_bypass == []
+
+
+def test_readiness_faulted_bypassable_zone():
+    zones = [make_zone(zone_id=1, magnet_open=True)]
+    result = evaluate_arm_readiness(zones, {1})
+    assert result.ready is True
+    assert [z["zone_id"] for z in result.zones_to_bypass] == [1]
+
+
+def test_readiness_faulted_non_bypassable_blocks():
+    zones = [make_zone(zone_id=1, magnet_open=True)]
+    result = evaluate_arm_readiness(zones, set())
+    assert result.ready is False
+    assert [z["zone_id"] for z in result.blocking_zones] == [1]
+
+
+def test_readiness_ec04_dual_technology_entry():
+    """Door open + curtain offline; curtain not bypassable => blocked."""
+    zones = [
+        make_zone(zone_id=1, name="Front door", magnet_open=True),
+        make_zone(zone_id=2, name="Curtain hall", status="offline"),
+    ]
+    result = evaluate_arm_readiness(zones, {1})
+    assert result.ready is False
+    assert [z["zone_id"] for z in result.blocking_zones] == [2]
+    assert [z["zone_id"] for z in result.zones_to_bypass] == [1]
+
+
+def test_readiness_flag_on_excluded_type_still_blocks():
+    """A bypassable flag on a 24h zone must not allow auto-bypass."""
+    zones = [make_zone(zone_id=1, zone_type="24h", status="trigger")]
+    result = evaluate_arm_readiness(zones, {1})
+    assert result.ready is False
+
+
+def test_readiness_skips_already_bypassed_zones():
+    """Panel-side bypasses are not touched nor counted."""
+    zones = [make_zone(zone_id=1, status="trigger", bypassed=True)]
+    result = evaluate_arm_readiness(zones, set())
+    assert result.ready is True
+    assert result.zones_to_bypass == []
+
+
+def test_readiness_home_skips_stay_bypassed_zones():
+    """In home mode, zones the panel stay-bypasses itself are ignored."""
+    zones = [make_zone(zone_id=1, magnet_open=True, stay_away=True)]
+    assert evaluate_arm_readiness(zones, set(), ARM_MODE_HOME).ready is True
+    # Away and vacation still consider the zone.
+    assert evaluate_arm_readiness(zones, set(), ARM_MODE_AWAY).ready is False
+    assert evaluate_arm_readiness(zones, set(), ARM_MODE_VACATION).ready is False
+    # Default mode is away for backwards compatibility.
+    assert evaluate_arm_readiness(zones, set()).ready is False
+
+
+def test_readiness_home_still_blocks_on_regular_zone():
+    """A faulted zone without the stay flag blocks home like any mode."""
+    zones = [make_zone(zone_id=1, magnet_open=True, stay_away=False)]
+    assert evaluate_arm_readiness(zones, set(), ARM_MODE_HOME).ready is False
+
+
+def test_readiness_per_area_breakdown():
+    zones = [
+        make_zone(zone_id=1, sub_system_no=1, magnet_open=True),
+        make_zone(zone_id=2, sub_system_no=2, status="offline"),
+        make_zone(zone_id=3, sub_system_no=2),
+    ]
+    result = evaluate_arm_readiness(zones, {1})
+    areas = result.per_area
+    assert areas[1]["ready"] is True
+    assert [z["zone_id"] for z in areas[1]["zones_to_bypass"]] == [1]
+    assert areas[2]["ready"] is False
+    assert [z["zone_id"] for z in areas[2]["blocking_zones"]] == [2]


### PR DESCRIPTION
Opt-in workflow that bypasses faulted zones at arming time and puts them back afterwards.

> Depends on #206 ; this branch includes that commit, so the diff drops to one commit once it merges.

### Why

`auto_bypass_on_arm` bypassed every blocking zone indiscriminately, from the poll cache, with no record of what it touched and no way to restore it.

### Change

Configured in the integration options: pick the arming modes, then a second page gives one zone picker per enabled mode. Only zones that can actually be bypassed are offered (instant zones the panel does not forbid).

At arming time zone states are re-read from the panel; selected faulted zones are bypassed, unselected ones abort the arm naming the offender, and a partial failure rolls back. Bypasses are tracked across restarts, removed once a zone recovers while armed, cleaned up on disarm, and reconciled if the panel drops them. The panel's "forbid bypass on arming" always wins.

Adds per-zone `bypassable_<mode>` and per-mode `ready_to_arm` sensors, `unbypass_zone` / `clear_all_bypasses` services (`recover_bypass_zone` kept as a deprecated alias), vacation arming, and bypass/arming events.

`arm_away_with_bypass` / `arm_home_with_bypass` previously accepted `with_bypass` and ignored it, silently doing a plain arm — they now force the flow.

### Compatibility

`auto_bypass_on_arm` is removed rather than mapped: mapping it would be worse than nothing, since modes enabled with no zones selected would *block* arming where the old option bypassed everything. Users opt in explicitly.

ISAPI primitives are isolated in `isapi_bypass.py` with no HA imports, so they could move to the `hikaxpro` library later.

Suite green (165 tests) across policy, arming flow, lifecycle, entities/services, options flow and ISAPI.